### PR TITLE
refactor: [003-USER-REGISTER] validate register-User

### DIFF
--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/Telephone.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/Telephone.java
@@ -1,0 +1,23 @@
+package org.jnjeaaaat.onbition.config.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+
+/**
+ * Telephone Validation 처리를 위한 Custom Annotation
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TelephoneValidator.class)
+public @interface Telephone {
+
+  String message() default "전화번호 형식이 일치하지 않습니다.";
+
+  Class[] groups() default {};
+
+  Class[] payload() default {};
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/TelephoneValidator.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/TelephoneValidator.java
@@ -1,0 +1,19 @@
+package org.jnjeaaaat.onbition.config.annotation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * @Telephone 어노테이션 구현체
+ */
+public class TelephoneValidator implements ConstraintValidator<Telephone, String> {
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return false;
+    }
+    return value.matches("01(?:0|1|[6-9])-(\\d{3}|\\d{4})-(\\d{4})$");
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseResponse.java
@@ -5,19 +5,24 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
+/**
+ * 클라이언트가 확인할 수 있는 ResponseDto
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class BaseResponse<T> {
 
-  private boolean success;
-  private int code;
-  private String message;
+  private boolean success;    // 성공 여부 true, false
+  private int code;           // HttpStatus 200, 400, ...
+  private String message;     // 성공 메세지, 에러 메세지
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private T result;
+  private T result;           // 성공 했을때 결과값
 
+  // 성공 케이스
   public static <T> BaseResponse<T> success(BaseStatus status, T result) {
     return BaseResponse.<T>builder()
         .success(status.isSuccess())
@@ -27,11 +32,21 @@ public class BaseResponse<T> {
         .build();
   }
 
+  // 실패 케이스 BaseException 을 처리함
   public static <T> BaseResponse<T> fail(BaseStatus status) {
     return BaseResponse.<T>builder()
         .success(status.isSuccess())
         .code(status.getCode())
         .message(status.getMessage())
+        .build();
+  }
+
+  // 실패 케이스 MethodArgumentNotValidException 처리
+  public static <T> BaseResponse<T> fail(HttpStatus status, String message) {
+    return BaseResponse.<T>builder()
+        .success(false)
+        .code(status.value())
+        .message(message)
         .build();
   }
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -17,12 +17,16 @@ public enum BaseStatus {
   /////////////////////////////// success response ///////////////////////////////
   // common
   SUCCESS(true, OK.value(), "성공했습니다."),
+
+  // user
   SUCCESS_SIGN_UP(true, OK.value(), "성공적으로 회원가입 되었습니다."),
 
 
 
   //////////////////////////////// failed response ////////////////////////////////
+  // user
   ALREADY_REGISTERED_USER(false, BAD_REQUEST.value(), "이미 가입된 유저입니다."),
+  DUPLICATED_USER_NAME(false, BAD_REQUEST.value(), "중복된 이름입니다."),
   ;
 
   private boolean success;

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignUpRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignUpRequest.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.jnjeaaaat.onbition.config.annotation.Telephone;
 
 /**
  * 회원가입에 필요한 Request class
@@ -22,7 +23,7 @@ public class SignUpRequest {
   @NotBlank(message = "이름을 입력해주세요.")
   private String name;
 
-  @NotBlank(message = "핸드폰 번호를 입력해주세요.")
+  @Telephone
   private String phone;
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/domain/repository/UserRepository.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/repository/UserRepository.java
@@ -21,4 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
   // uid 값으로 존재하는 유저인지 확인
   boolean existsByUidAndDeletedAt(String uid, LocalDateTime deletedAt);
 
+  // name 이 중복되는지 확인
+  boolean existsByNameAndDeletedAt(String name, LocalDateTime deletedAt);
+
 }

--- a/src/main/java/org/jnjeaaaat/onbition/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/jnjeaaaat/onbition/exception/GlobalExceptionHandler.java
@@ -1,9 +1,13 @@
 package org.jnjeaaaat.onbition.exception;
 
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -27,6 +31,31 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .badRequest()
         .body(BaseResponse.fail(e.getStatus()));
+  }
+
+  /*
+  MethodArgumentNotValidException Handler
+  Validation 처리를 할때 생긴 오류들을 처리한다.
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<BaseResponse> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e, HttpServletRequest request) {
+
+    // 발생한 FiledError 들을 list 에 저장
+    List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+    FieldError fieldError = fieldErrors.get(0);   // 첫 번째 에러
+    String fieldName = fieldError.getField();  // 필드명
+
+    log.error("[MethodArgumentNotValidException] fieldName : {} ", fieldName,
+        fieldError.getDefaultMessage() + " uri: {}", request.getRequestURI());
+
+    return ResponseEntity
+        .badRequest()
+        .body(BaseResponse.fail(
+                HttpStatus.BAD_REQUEST,
+                fieldError.getDefaultMessage()
+            )
+        );
   }
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/SignServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/SignServiceImpl.java
@@ -1,6 +1,7 @@
 package org.jnjeaaaat.onbition.service.impl;
 
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.ALREADY_REGISTERED_USER;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.DUPLICATED_USER_NAME;
 
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
@@ -43,9 +44,10 @@ public class SignServiceImpl implements SignService {
     if (userRepository.existsByUidAndDeletedAt(request.getUid(), null)) {
       throw new BaseException(ALREADY_REGISTERED_USER);
     }
-//    if (userRepository.findByUid(request.getUid()).isPresent()) {
-//      throw new BaseException(ALREADY_REGISTERED_USER);
-//    }
+    // 유저 이름이 중복될때
+    if (userRepository.existsByNameAndDeletedAt(request.getName(), null)) {
+      throw new BaseException(DUPLICATED_USER_NAME);
+    }
 
     // 파일 저장 후 url 가져오기
     String imageUrl = imageService.saveImage(image, FileFolder.PROFILE_IMAGE);

--- a/src/main/java/org/jnjeaaaat/onbition/web/SignController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/SignController.java
@@ -3,6 +3,7 @@ package org.jnjeaaaat.onbition.web;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_SIGN_UP;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
@@ -37,7 +38,7 @@ public class SignController {
   // Multipart, RequestPart 에 Json 형태의 값을 받기 위해 MediaType 을 설정해줘야 한다.
   public BaseResponse<SignUpResponse> signUp(
       @RequestPart(value = "image") MultipartFile image, // MultipartFile 이미지 request
-      @RequestPart(value = "request") SignUpRequest request, // 나머지 유저 정보 request
+      @Valid @RequestPart(value = "request") SignUpRequest request, // 나머지 유저 정보 request
       HttpServletRequest httpServletRequest ) { // uri 을 받기 위한 servletRequest
 
     // 요청 uri log


### PR DESCRIPTION
Changes
---
1. Telephone 어노테이션 추가 (Custom Annotation)
   - SignUpRequest 클래스 `phone` 필드에 `Pattern` 어노테이션을 추가할수도 있지만
   코드가 길어져서 `Telephone` 이라는 커스텀 어노테이션 생성해서 `phone` 필드에 적용
2. sign-up API 의 RequestPart에 Valid 추가
   - SignUpRequest Dto의 validation 어노테이션들을 처리할 수 있게
   `RequestPart`에 `Valid` 어노테이션을 추가한다.
3. `GlobalExceptionHandler` 수정
   - Valid 어노테이션으로 처리하는 exception은 `MethodArgumentNotValidException` 로
   따로 처리해줘야 한다.
4. uid exists 처럼 name exists 확인

Background
---
- 데이터베이스에 핸드폰번호를 규칙에 맞게 저장하려면 유저가 요청하는 전화번호 형식이 규칙적이어야 하기 때문에
정규식으로 맞출 필요성을 느꼈다.

- Pattern 어노테이션을 사용할수도 있지만
custom 어노테이션을 만들어서 눈에 잘 들어올 수 있게 코드를 짜야한다.

- Valid로 처리하는 excpetion은 따로 처리해줘야한다.

Issues
---
Resolved: #7, #9 