### PR TITLE
test: [TEXT-VALIDATION-PARAM] "add validation SMS param"

### DIFF
--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/Telephone.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/Telephone.java
@@ -9,7 +9,7 @@ import javax.validation.Constraint;
 /**
  * Telephone Validation 처리를 위한 Custom Annotation
  */
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = TelephoneValidator.class)
 public @interface Telephone {

--- a/src/main/java/org/jnjeaaaat/onbition/web/SMSController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/SMSController.java
@@ -3,11 +3,14 @@ package org.jnjeaaaat.onbition.web;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_AUTH_TEXT;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_SEND_TEXT;
 
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.config.annotation.Telephone;
 import org.jnjeaaaat.onbition.domain.dto.auth.SendTextResponse;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
 import org.jnjeaaaat.onbition.service.SMSService;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 인증코드 전송, 인증코드 확인 api
  */
+@Validated
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -26,7 +30,7 @@ public class SMSController {
 
   // 문자로 인증코드 전송
   @PostMapping("")
-  public BaseResponse<SendTextResponse> sendMessage(@RequestParam("phone") String phone) {
+  public BaseResponse<SendTextResponse> sendMessage(@RequestParam("phone") @Telephone String phone) {
 
     log.info("[inputPhoneNum] 핸드폰 번호 본인 인증");
 
@@ -39,8 +43,8 @@ public class SMSController {
   // 인증코드 일치
   @PostMapping("/authentication")
   public BaseResponse<String> authenticatePhoneNum(
-      @RequestParam("phone") String phone,
-      @RequestParam("code") String code) {
+      @RequestParam("phone") @Telephone String phone,
+      @RequestParam("code") @NotBlank String code) {
 
     log.info("[authenticatePhoneNum] 핸드폰 번호 본인 인증 - 코드 입력");
 


### PR DESCRIPTION
Changes
---
1. Telephone 어노테이션 Target 수정
2. SMSController의 RequestParam에 Telephone 어노테이션 적용
3. SMSController 상단에 Validated 어노테이션 적용

Background
---
문자전송, 인증코드 확인 api에는 전화번호 형식에 대한 validation이 없어서 필요했다.
이미 만들어놓은 Telephone 어노테이션을 적용하고싶었다.

Discuss
---
custom annotation Target 어노테이션에 ElementType.PARAMETER 만 추가하면 해결되는 문제였는데,
코드를 전체적으로 다 바꿔야하나 난감해하다가 해결했다.

Issues
---
Related to: #17