### PR TITLE
feat: [USER-MODIFY-INFO] 유저 정보(이름, 프로필사진, 비밀번호) 변경

### DIFF
--- a/doc/TROUBLE_SHOOTING.md
+++ b/doc/TROUBLE_SHOOTING.md
@@ -1,2 +1,4 @@
 # Trouble Shooting
-프로젝트를 진행하면서 발생한 문제점들과 해결법 서술합니다.
+
+## ✨ java 8 LocalDateTime type not support
+### [해결과정](https://jnjeaaaat.tistory.com/79)

--- a/src/main/java/org/jnjeaaaat/onbition/OnbitionApplication.java
+++ b/src/main/java/org/jnjeaaaat/onbition/OnbitionApplication.java
@@ -1,13 +1,13 @@
 package org.jnjeaaaat.onbition;
 
+import org.jnjeaaaat.onbition.config.client.SmsClient;
 import org.jnjeaaaat.onbition.config.storage.S3Component;
-import org.jnjeaaaat.onbition.util.SmsUtil;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({S3Component.class, SmsUtil.class})
+@EnableConfigurationProperties({S3Component.class, SmsClient.class})
 public class OnbitionApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/jnjeaaaat/onbition/config/ObjectMapperConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/ObjectMapperConfig.java
@@ -1,15 +1,20 @@
 package org.jnjeaaaat.onbition.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Configuration;
 
-@Component
+@Configuration
 public class ObjectMapperConfig {
 
   @Bean
   public ObjectMapper objectMapper() {
-    return new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    return objectMapper;
   }
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/config/client/SmsClient.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/client/SmsClient.java
@@ -1,4 +1,4 @@
-package org.jnjeaaaat.onbition.util;
+package org.jnjeaaaat.onbition.config.client;
 
 import javax.annotation.PostConstruct;
 import lombok.Data;
@@ -12,13 +12,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 /**
- * 문자전송 Util Class
+ * 문자전송 Client Class
  */
 @Slf4j
 @Component
 @ConfigurationProperties(prefix = "coolsms.api")
 @Data
-public class SmsUtil {
+public class SmsClient {
 
   private String from;
   private String key;
@@ -35,20 +35,28 @@ public class SmsUtil {
         "https://api.coolsms.co.kr");
   }
 
-  // 단일 메시지 발송 예제
-  public SingleMessageSentResponse sendOne(String to, String verificationCode) {
+  // 회원가입 인증코드 발송
+  public SingleMessageSentResponse sendVerificationCode(String to, String verificationCode) {
 
     log.info("[sendMessage] phone number : {}, code : {}", to, verificationCode);
     Message message = new Message();
     // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
     message.setFrom(from);
     message.setTo(to.replace("-", ""));
-    if (verificationCode.length() == 6) {
-      message.setText("[Onbition] 아래의 인증번호를 입력해주세요.\n\n" + verificationCode);
-    } else {
-      message.setText("[Onbition] 비밀번호가 초기화 되었습니다.\n\n" + verificationCode);
-    }
+    message.setText("[Onbition] 아래의 인증번호를 입력해주세요.\n" + verificationCode);
 
+    return this.defaultMessageService.sendOne(new SingleMessageSendingRequest(message));
+  }
+
+  // 비밀번호 초기화 문자 발송
+  public SingleMessageSentResponse sendPasswordResetCode(String to, String newPassword) {
+
+    log.info("[sendMessage] phone number : {}, password : {}", to, newPassword);
+    Message message = new Message();
+    // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
+    message.setFrom(from);
+    message.setTo(to.replace("-", ""));
+    message.setText("[Onbition] 비밀번호가 초기화 되었습니다.\n" + newPassword);
 
     return this.defaultMessageService.sendOne(new SingleMessageSendingRequest(message));
   }

--- a/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
@@ -40,6 +40,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers("/**/sign-up").permitAll()
         .antMatchers("/**/sign-in").permitAll()
+        .antMatchers("/**/reset").permitAll()
+        .antMatchers("/**/sms/**").permitAll()
 
         .anyRequest().hasAnyRole("VIEWER")
 

--- a/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
@@ -40,14 +40,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers("/**/sign-up").permitAll()
         .antMatchers("/**/sign-in").permitAll()
-        .antMatchers("/**/logout").hasAnyRole("VIEWER")
+
+        .anyRequest().hasAnyRole("VIEWER")
 
         /*
         hasRole, hasAnyRole 로 권한을 걸어줘야 exceptionHandling 에서 걸러내고
         CustomAuthenticationEntryPoint 클래스에서 처리할 수 있음
          */
-        .antMatchers("/api/v1/test").hasAnyRole("VIEWER")
-
         .and()
         // 유저 권한 예외처리
         .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler(objectMapper))

--- a/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers("/**/sign-up").permitAll()
         .antMatchers("/**/sign-in").permitAll()
+        .antMatchers("/**/re-token").permitAll()
         .antMatchers("/**/reset").permitAll()
         .antMatchers("/**/sms/**").permitAll()
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -33,6 +33,7 @@ public enum BaseStatus {
 
   // user
   SUCCESS_UPDATE_USER(true, OK.value(), "유저 정보가 변경되었습니다."),
+  SUCCESS_UPDATE_PASSWORD(true, OK.value(), "비밀번호가 변경되었습니다."),
 
 
 
@@ -42,6 +43,7 @@ public enum BaseStatus {
   DUPLICATED_USER_NAME(false, BAD_REQUEST.value(), "중복된 이름입니다."),
   NOT_FOUND_USER(false, BAD_REQUEST.value(), "등록되지 않은 유저입니다."),
   UN_MATCH_PASSWORD(false, BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+  SAME_PASSWORD(false, BAD_REQUEST.value(), "동일한 비밀번호로는 변경할 수 없습니다."),
 
   // sms auth
   NEED_REPOST_PHONE_NUMBER(false, BAD_REQUEST.value(), "번호를 다시 입력해주세요."),

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -62,8 +62,6 @@ public enum BaseStatus {
 
 
   // file
-  FILE_UPLOAD_ERROR(false, INTERNAL_SERVER_ERROR.value(), "파일 업로드에 실패하였습니다."),
-  FILE_DELETE_ERROR(false, INTERNAL_SERVER_ERROR.value(), "파일 삭제에 실패하였습니다."),
   NOT_FOUND_FILE(false, INTERNAL_SERVER_ERROR.value(), "파일을 찾을 수 없습니다."),
   
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -1,6 +1,7 @@
 package org.jnjeaaaat.onbition.domain.dto.base;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
@@ -30,6 +31,9 @@ public enum BaseStatus {
   SUCCESS_REISSUE_TOKEN(true, OK.value(), "토큰이 재발급 되었습니다."),
   SUCCESS_LOG_OUT(true, OK.value(), "로그아웃 되었습니다."),
 
+  // user
+  SUCCESS_UPDATE_USER(true, OK.value(), "유저 정보가 변경되었습니다."),
+
 
 
   //////////////////////////////// failed response ////////////////////////////////
@@ -51,6 +55,12 @@ public enum BaseStatus {
   NOT_FOUND_TOKEN(false, UNAUTHORIZED.value(), "토큰이 존재하지 않습니다."),
   INVALID_TOKEN(false, UNAUTHORIZED.value(), "유효하지 않는 토큰입니다."),
   ALREADY_LOGOUT(false, UNAUTHORIZED.value(), "이미 로그아웃 상태입니다."),
+
+
+  // file
+  FILE_UPLOAD_ERROR(false, INTERNAL_SERVER_ERROR.value(), "파일 업로드에 실패하였습니다."),
+  FILE_DELETE_ERROR(false, INTERNAL_SERVER_ERROR.value(), "파일 삭제에 실패하였습니다."),
+  NOT_FOUND_FILE(false, INTERNAL_SERVER_ERROR.value(), "파일을 찾을 수 없습니다."),
   
 
   ;

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -34,6 +34,7 @@ public enum BaseStatus {
   // user
   SUCCESS_UPDATE_USER(true, OK.value(), "유저 정보가 변경되었습니다."),
   SUCCESS_UPDATE_PASSWORD(true, OK.value(), "비밀번호가 변경되었습니다."),
+  SUCCESS_RESET_PASSWORD(true, OK.value(), "비밀번호가 초기화 되었습니다."),
 
 
 
@@ -44,6 +45,7 @@ public enum BaseStatus {
   NOT_FOUND_USER(false, BAD_REQUEST.value(), "등록되지 않은 유저입니다."),
   UN_MATCH_PASSWORD(false, BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
   SAME_PASSWORD(false, BAD_REQUEST.value(), "동일한 비밀번호로는 변경할 수 없습니다."),
+  UN_MATCH_PHONE_NUM(false, BAD_REQUEST.value(), "전화번호가 일치하지 않습니다."),
 
   // sms auth
   NEED_REPOST_PHONE_NUMBER(false, BAD_REQUEST.value(), "번호를 다시 입력해주세요."),

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/PasswordModifyRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/PasswordModifyRequest.java
@@ -1,0 +1,22 @@
+package org.jnjeaaaat.onbition.domain.dto.user;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 유저 비밀번호 변경 Request class
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordModifyRequest {
+
+  @NotBlank(message = "비밀번호를 입력해주세요.")
+  private String password;
+
+  @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
+  private String newPassword;
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/ResetPasswordRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/ResetPasswordRequest.java
@@ -1,0 +1,23 @@
+package org.jnjeaaaat.onbition.domain.dto.user;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jnjeaaaat.onbition.config.annotation.Telephone;
+
+/**
+ * 비밀번호 초기화 Request class
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetPasswordRequest {
+
+  @NotBlank(message = "아이디를 입력해주세요.")
+  private String uid;
+
+  @Telephone
+  private String phone;
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyRequest.java
@@ -1,0 +1,20 @@
+package org.jnjeaaaat.onbition.domain.dto.user;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserModifyRequest {
+
+  @NotBlank(message = "이름을 입력해주세요.")
+  private String name;
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyRequest.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * 유저 정보 변경 Request class
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyResponse.java
@@ -1,12 +1,14 @@
 package org.jnjeaaaat.onbition.domain.dto.user;
 
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * 유저 정보 변경 Response class
+ */
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,7 +20,6 @@ public class UserModifyResponse {
   private String uid;
   private String name;
   private String profileImgUrl;
-  private LocalDateTime updatedAt;
 
   public static UserModifyResponse from(UserDto userDto) {
     return UserModifyResponse.builder()
@@ -26,7 +27,6 @@ public class UserModifyResponse {
         .uid(userDto.getUid())
         .name(userDto.getName())
         .profileImgUrl(userDto.getProfileImgUrl())
-        .updatedAt(userDto.getUpdatedAt())
         .build();
   }
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserModifyResponse.java
@@ -1,0 +1,33 @@
+package org.jnjeaaaat.onbition.domain.dto.user;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserModifyResponse {
+
+  private Long id;
+  private String uid;
+  private String name;
+  private String profileImgUrl;
+  private LocalDateTime updatedAt;
+
+  public static UserModifyResponse from(UserDto userDto) {
+    return UserModifyResponse.builder()
+        .id(userDto.getId())
+        .uid(userDto.getUid())
+        .name(userDto.getName())
+        .profileImgUrl(userDto.getProfileImgUrl())
+        .updatedAt(userDto.getUpdatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/BaseEntity.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/BaseEntity.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -21,9 +20,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 @MappedSuperclass
-@Builder(builderMethodName = "doesNotUseThisBuilder")
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
   // 생성일자
   @CreatedDate

--- a/src/main/java/org/jnjeaaaat/onbition/service/FileService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/FileService.java
@@ -1,6 +1,7 @@
 package org.jnjeaaaat.onbition.service;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -10,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface FileService {
 
   // 파일 업로드
-  String uploadFile(MultipartFile file, FileFolder fileFolder);
+  String uploadFile(MultipartFile file, FileFolder fileFolder) throws IOException;
 
   // 파일 삭제
   void deleteFile(String fileName);

--- a/src/main/java/org/jnjeaaaat/onbition/service/ImageService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/ImageService.java
@@ -11,4 +11,6 @@ public interface ImageService {
   // 이미지 저장
   String saveImage(MultipartFile file, FileFolder fileFolder);
 
+  // 이미지 삭제
+  void deleteImage(String filePath);
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/ImageService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/ImageService.java
@@ -1,5 +1,6 @@
 package org.jnjeaaaat.onbition.service;
 
+import java.io.IOException;
 import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,7 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageService {
 
   // 이미지 저장
-  String saveImage(MultipartFile file, FileFolder fileFolder);
+  String saveImage(MultipartFile file, FileFolder fileFolder) throws IOException;
 
   // 이미지 삭제
   void deleteImage(String filePath);

--- a/src/main/java/org/jnjeaaaat/onbition/service/SignService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/SignService.java
@@ -1,5 +1,6 @@
 package org.jnjeaaaat.onbition.service;
 
+import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import org.jnjeaaaat.onbition.domain.dto.auth.ReissueResponse;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignInRequest;
@@ -14,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface SignService {
 
   // 회원가입
-  SignUpResponse signUp(MultipartFile image, SignUpRequest request);
+  SignUpResponse signUp(MultipartFile image, SignUpRequest request) throws IOException;
 
   // 로그인
   SignInResponse signIn(SignInRequest request);

--- a/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
@@ -1,5 +1,6 @@
 package org.jnjeaaaat.onbition.service;
 
+import org.jnjeaaaat.onbition.domain.dto.user.PasswordModifyRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,4 +13,6 @@ public interface UserService {
   // 프로필사진, 이름 변경
   UserModifyResponse updateUser(Long userId, MultipartFile image, UserModifyRequest request);
 
+  // 비밀번호 변경
+  void updatePassword(Long userId, PasswordModifyRequest request);
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
@@ -1,5 +1,6 @@
 package org.jnjeaaaat.onbition.service;
 
+import java.io.IOException;
 import org.jnjeaaaat.onbition.domain.dto.user.PasswordModifyRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.ResetPasswordRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
@@ -12,7 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 public interface UserService {
 
   // 프로필사진, 이름 변경
-  UserModifyResponse updateUser(Long userId, MultipartFile image, UserModifyRequest request);
+  UserModifyResponse updateUser(Long userId, MultipartFile image, UserModifyRequest request)
+      throws IOException;
 
   // 비밀번호 변경
   void updatePassword(Long userId, PasswordModifyRequest request);

--- a/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
@@ -1,0 +1,15 @@
+package org.jnjeaaaat.onbition.service;
+
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 유저 정보 변경, 비밀번호 변경, 유저 조회 기능 Interface
+ */
+public interface UserService {
+
+  // 프로필사진, 이름 변경
+  UserModifyResponse updateUser(Long userId, MultipartFile image, UserModifyRequest request);
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/UserService.java
@@ -1,6 +1,7 @@
 package org.jnjeaaaat.onbition.service;
 
 import org.jnjeaaaat.onbition.domain.dto.user.PasswordModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.ResetPasswordRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,4 +16,7 @@ public interface UserService {
 
   // 비밀번호 변경
   void updatePassword(Long userId, PasswordModifyRequest request);
+
+  // 비밀번호 리셋 다시설정
+  void resetPassword(ResetPasswordRequest request);
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/ProfileImageServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/ProfileImageServiceImpl.java
@@ -27,4 +27,13 @@ public class ProfileImageServiceImpl implements ImageService {
     return fileService.uploadFile(image, fileFolder);
   }
 
+  /*
+  [이미지 삭제]
+  file 경로값을 받아 해당 이미지(파일) 삭제
+   */
+  @Override
+  public void deleteImage(String filePath) {
+    fileService.deleteFile(filePath);
+  }
+
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/ProfileImageServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/ProfileImageServiceImpl.java
@@ -1,5 +1,6 @@
 package org.jnjeaaaat.onbition.service.impl;
 
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
@@ -23,7 +24,7 @@ public class ProfileImageServiceImpl implements ImageService {
   MultipartFile 타입의 image, PROFILE_IMAGE
    */
   @Override
-  public String saveImage(MultipartFile image, FileFolder fileFolder) {
+  public String saveImage(MultipartFile image, FileFolder fileFolder) throws IOException {
     return fileService.uploadFile(image, fileFolder);
   }
 

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/S3ServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/S3ServiceImpl.java
@@ -1,5 +1,9 @@
 package org.jnjeaaaat.onbition.service.impl;
 
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.FILE_DELETE_ERROR;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.FILE_UPLOAD_ERROR;
+
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -12,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.config.storage.S3Component;
 import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
+import org.jnjeaaaat.onbition.exception.BaseException;
 import org.jnjeaaaat.onbition.service.FileService;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,6 +35,7 @@ public class S3ServiceImpl implements FileService {
   // 파일 저장
   @Override
   public String uploadFile(MultipartFile file, FileFolder fileFolder) {
+    log.info("[uploadFile] 파일 업로드 시도");
     //파일 이름 생성
     String fileName = getFileFolder(fileFolder) + createFileName(file.getOriginalFilename());
 
@@ -46,8 +52,7 @@ public class S3ServiceImpl implements FileService {
               .withCannedAcl(CannedAccessControlList.PublicReadWrite)
       );
     } catch (IOException e) {
-      throw new IllegalArgumentException(
-          String.format("파일 변환 중 에러가 발생하였습니다. (%s)", file.getOriginalFilename()));
+      throw new BaseException(FILE_UPLOAD_ERROR);
     }
 
     return getFileUrl(fileName);
@@ -55,8 +60,26 @@ public class S3ServiceImpl implements FileService {
 
   // 파일 삭제
   @Override
-  public void deleteFile(String fileName) {
+  public void deleteFile(String filePath) {
+    log.info("[deleteFile] S3 파일 삭제 시도");
+    String key = getDeleteKey(filePath); // 폴더/파일.확장자
+    log.info("[deleteFile] key 값 : {}", key);
 
+    try {
+
+      amazonS3.deleteObject(s3Component.getBucket(), key);
+
+    } catch (AmazonServiceException e) {
+      throw new BaseException(FILE_DELETE_ERROR);
+    }
+
+    log.info("[deleteFile] S3에 있는 파일 삭제");
+  }
+
+  // deleteObject key 생성 (폴더/파일명.확장자)
+  private String getDeleteKey(String filePath) {
+    String key = filePath.substring(filePath.indexOf(s3Component.getBucket())); // https:// 제거
+    return key.substring(key.indexOf("/") + 1); // user/profile/파일명.확장자
   }
 
   // 파일 url 정보 조회
@@ -75,16 +98,17 @@ public class S3ServiceImpl implements FileService {
   @Override
   public String getFileFolder(FileFolder fileFolder) {
     String folder = "";
-    if(fileFolder == FileFolder.PROFILE_IMAGE) {
+    if (fileFolder == FileFolder.PROFILE_IMAGE) {
       folder = s3Component.getFolder().getProfile();
 
-    }else if(fileFolder ==FileFolder.PAINT_IMAGE){
+    } else if (fileFolder == FileFolder.PAINT_IMAGE) {
       folder = s3Component.getFolder().getPaint();
     }
     return folder;
   }
 
   private void validateFileExists(String fileName) throws FileNotFoundException {
+    log.info("[validateFileExists] 파일 유무 확인");
     if (!amazonS3.doesObjectExist(s3Component.getBucket(), fileName)) {
       throw new FileNotFoundException();
     }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/S3ServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/S3ServiceImpl.java
@@ -1,8 +1,5 @@
 package org.jnjeaaaat.onbition.service.impl;
 
-import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.FILE_DELETE_ERROR;
-import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.FILE_UPLOAD_ERROR;
-
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
@@ -16,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.config.storage.S3Component;
 import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
-import org.jnjeaaaat.onbition.exception.BaseException;
 import org.jnjeaaaat.onbition.service.FileService;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,7 +30,7 @@ public class S3ServiceImpl implements FileService {
 
   // 파일 저장
   @Override
-  public String uploadFile(MultipartFile file, FileFolder fileFolder) {
+  public String uploadFile(MultipartFile file, FileFolder fileFolder) throws IOException {
     log.info("[uploadFile] 파일 업로드 시도");
     //파일 이름 생성
     String fileName = getFileFolder(fileFolder) + createFileName(file.getOriginalFilename());
@@ -52,7 +48,7 @@ public class S3ServiceImpl implements FileService {
               .withCannedAcl(CannedAccessControlList.PublicReadWrite)
       );
     } catch (IOException e) {
-      throw new BaseException(FILE_UPLOAD_ERROR);
+      throw new IOException();
     }
 
     return getFileUrl(fileName);
@@ -70,7 +66,8 @@ public class S3ServiceImpl implements FileService {
       amazonS3.deleteObject(s3Component.getBucket(), key);
 
     } catch (AmazonServiceException e) {
-      throw new BaseException(FILE_DELETE_ERROR);
+      log.error("[deleteFile] 파일 삭제 실패");
+      throw new AmazonServiceException(e.getMessage());
     }
 
     log.info("[deleteFile] S3에 있는 파일 삭제");

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/auth/SMSServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/auth/SMSServiceImpl.java
@@ -7,11 +7,11 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.jnjeaaaat.onbition.config.client.SmsClient;
 import org.jnjeaaaat.onbition.domain.dto.auth.SendTextResponse;
 import org.jnjeaaaat.onbition.exception.BaseException;
 import org.jnjeaaaat.onbition.service.SMSService;
 import org.jnjeaaaat.onbition.util.RedisUtil;
-import org.jnjeaaaat.onbition.util.SmsUtil;
 import org.springframework.stereotype.Service;
 
 /**
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SMSServiceImpl implements SMSService {
 
-  private final SmsUtil smsUtil;
+  private final SmsClient smsClient;
   private final RedisUtil redisUtil;
 
   private final Long expireTimeMs = 60 * 3L; // 인증코드 유효기간
@@ -39,7 +39,7 @@ public class SMSServiceImpl implements SMSService {
 
     log.info("[sendMessage] 해당 번호로 문자 전송");
     // 문자인증을 위한 문자 전송
-    smsUtil.sendOne(phone, verificationCode);
+    smsClient.sendVerificationCode(phone, verificationCode);
     log.info("[sendMessage] 문자 전송 성공");
 
     log.info("[saveToRedis] Redis 서버에 인증코드 저장");

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/auth/SignServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/auth/SignServiceImpl.java
@@ -10,6 +10,7 @@ import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.REFRESH_TOKEN_EX
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UN_MATCH_PASSWORD;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import java.io.IOException;
 import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -56,7 +57,7 @@ public class SignServiceImpl implements SignService {
   Response: user PK, profileImgUrl, uid, name, roles
    */
   @Override
-  public SignUpResponse signUp(MultipartFile image, SignUpRequest request) {
+  public SignUpResponse signUp(MultipartFile image, SignUpRequest request) throws IOException {
 
     log.info("[signUp] 회원가입 요청 - uid : {}", request.getUid());
     // 이미 존재하는 유저일때

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImpl.java
@@ -1,0 +1,90 @@
+package org.jnjeaaaat.onbition.service.impl.user;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.DUPLICATED_USER_NAME;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_USER;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NO_AUTHORITY;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
+import org.jnjeaaaat.onbition.domain.dto.user.UserDto;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.exception.BaseException;
+import org.jnjeaaaat.onbition.service.ImageService;
+import org.jnjeaaaat.onbition.service.UserService;
+import org.jnjeaaaat.onbition.util.JwtTokenUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+  private final ImageService imageService;
+  private final UserRepository userRepository;
+  private final JwtTokenUtil jwtTokenUtil;
+
+  /*
+  [유저정보변경]
+  Request: 유저 PK, MultipartFile 이미지, 유저 이름
+  Response: 유저 PK, 유저 id, 유저 이름, 유저 프로필사진, 유저 변경날짜
+   */
+  @Override
+  @Transactional
+  public UserModifyResponse updateUser(Long userId, MultipartFile image, UserModifyRequest request) {
+    log.info("[updateUser] 유저 정보 변경 - 유저 id : {}", userId);
+    // 토큰 정보의 user 와 요청하는 userId 가 다를때
+    if (!Objects.equals(userId, jwtTokenUtil.getUserIdFromToken())) {
+      throw new BaseException(NO_AUTHORITY);
+    }
+
+    // 유저 정보 추출
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+
+    if (image != null && !image.isEmpty()) {
+      log.info("[updateUser] 프로필 사진 변경");
+      updateUserProfileImg(user, image);
+    }
+    if (!Objects.equals(user.getName(), request.getName())) {
+      log.info("[updateUser] 유저 이름 변경");
+      updateUserName(user, request.getName());
+    }
+
+    return UserModifyResponse.from(
+        UserDto.from(user)
+    );
+  }
+
+  /*
+  프로필 사진 업데이트
+   */
+  private void updateUserProfileImg(User user, MultipartFile image) {
+    // 원래 이미지 삭제
+    String oldFile = user.getProfileImgUrl();
+    imageService.deleteImage(oldFile);
+
+    // 새로운 이미지 저장
+    String newFile = imageService.saveImage(image, FileFolder.PROFILE_IMAGE);
+    user.setProfileImgUrl(newFile);
+  }
+
+  /*
+  유저 이름 업데이트 (변경시)
+   */
+  private void updateUserName(User user, String name) {
+    // 이름 중복
+    if (userRepository.existsByNameAndDeletedAtNull(name)) {
+      throw new BaseException(DUPLICATED_USER_NAME);
+    }
+
+    user.setName(name);
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/util/SmsUtil.java
+++ b/src/main/java/org/jnjeaaaat/onbition/util/SmsUtil.java
@@ -2,6 +2,7 @@ package org.jnjeaaaat.onbition.util;
 
 import javax.annotation.PostConstruct;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 /**
  * 문자전송 Util Class
  */
+@Slf4j
 @Component
 @ConfigurationProperties(prefix = "coolsms.api")
 @Data
@@ -35,11 +37,18 @@ public class SmsUtil {
 
   // 단일 메시지 발송 예제
   public SingleMessageSentResponse sendOne(String to, String verificationCode) {
+
+    log.info("[sendMessage] phone number : {}, code : {}", to, verificationCode);
     Message message = new Message();
     // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
     message.setFrom(from);
     message.setTo(to.replace("-", ""));
-    message.setText("[Onbition] 아래의 인증번호를 입력해주세요\n" + verificationCode);
+    if (verificationCode.length() == 6) {
+      message.setText("[Onbition] 아래의 인증번호를 입력해주세요.\n\n" + verificationCode);
+    } else {
+      message.setText("[Onbition] 비밀번호가 초기화 되었습니다.\n\n" + verificationCode);
+    }
+
 
     return this.defaultMessageService.sendOne(new SingleMessageSendingRequest(message));
   }

--- a/src/main/java/org/jnjeaaaat/onbition/web/SignController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/SignController.java
@@ -6,6 +6,7 @@ import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_REISSUE_
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_SIGN_IN;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_SIGN_UP;
 
+import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class SignController {
       @RequestPart(value = "image", required = false) MultipartFile image,
       // MultipartFile 이미지 request
       @Valid @RequestPart(value = "request") SignUpRequest request, // 나머지 유저 정보 request
-      HttpServletRequest httpServletRequest) { // uri 을 받기 위한 servletRequest
+      HttpServletRequest httpServletRequest) throws IOException { // uri 을 받기 위한 servletRequest
 
     // 요청 uri log
     log.info("[signUp] 회원가입 요청 - uri : {}", httpServletRequest.getRequestURI());

--- a/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
@@ -1,5 +1,6 @@
 package org.jnjeaaaat.onbition.web;
 
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_UPDATE_PASSWORD;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_UPDATE_USER;
 
 import javax.validation.Valid;
@@ -7,6 +8,7 @@ import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
+import org.jnjeaaaat.onbition.domain.dto.user.PasswordModifyRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
 import org.jnjeaaaat.onbition.service.UserService;
@@ -14,11 +16,15 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 유저 정보 변경, 비밀번호 변경, 유저 조회 api
+ */
 @Validated
 @Slf4j
 @RestController
@@ -28,6 +34,11 @@ public class UserController {
 
   private final UserService userService;
 
+  /*
+  [유저 정보 변경]
+  Request: 유저 PK, MultipartFile image, 유저 이름
+  Response: 유저 PK, 유저 id, 유저 이름, 유저 프로필사진
+   */
   @PutMapping(value = "/{userId}", consumes = {MediaType.APPLICATION_JSON_VALUE,
       MediaType.MULTIPART_FORM_DATA_VALUE})
   public BaseResponse<UserModifyResponse> updateUser(
@@ -41,5 +52,24 @@ public class UserController {
         userService.updateUser(userId, image, request)
     );
   }
+
+  /*
+  [비밀번호 변경]
+  Request: oldPassword, newPassword
+  Response: success message
+   */
+  @PutMapping("/pwd/{userId}")
+  public BaseResponse updatePassword(
+      @Positive @PathVariable Long userId,
+      @Valid @RequestBody PasswordModifyRequest request) {
+
+    log.info("[updatePassword] 유저 비밀번호 변경 요청");
+    userService.updatePassword(userId, request);
+
+    return BaseResponse.success(
+        SUCCESS_UPDATE_PASSWORD
+    );
+  }
+
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
@@ -1,5 +1,6 @@
 package org.jnjeaaaat.onbition.web;
 
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_RESET_PASSWORD;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_UPDATE_PASSWORD;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_UPDATE_USER;
 
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
 import org.jnjeaaaat.onbition.domain.dto.user.PasswordModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.ResetPasswordRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
 import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
 import org.jnjeaaaat.onbition.service.UserService;
@@ -69,6 +71,23 @@ public class UserController {
     return BaseResponse.success(
         SUCCESS_UPDATE_PASSWORD
     );
+  }
+
+  /*
+  [비밀번호 초기화]
+  Request: 유저 id, 유저 핸드폰번호
+  Response: success message
+   */
+  @PutMapping("/pwd/reset")
+  public BaseResponse resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+
+    log.info("[resetPassword] 유저 비밀번호 초기화 요청");
+    userService.resetPassword(request);
+
+    return BaseResponse.success(
+        SUCCESS_RESET_PASSWORD
+    );
+
   }
 
 

--- a/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
@@ -4,6 +4,7 @@ import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_RESET_PA
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_UPDATE_PASSWORD;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_UPDATE_USER;
 
+import java.io.IOException;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class UserController {
   public BaseResponse<UserModifyResponse> updateUser(
       @Positive @PathVariable Long userId,
       @RequestPart(value = "image", required = false) MultipartFile image,
-      @Valid @RequestPart(value = "request") UserModifyRequest request) {
+      @Valid @RequestPart(value = "request") UserModifyRequest request) throws IOException {
 
     log.info("[updateUser] 유저 정보 변경 요청");
     return BaseResponse.success(

--- a/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/UserController.java
@@ -1,0 +1,45 @@
+package org.jnjeaaaat.onbition.web;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_UPDATE_USER;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
+import org.jnjeaaaat.onbition.service.UserService;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Validated
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+  private final UserService userService;
+
+  @PutMapping(value = "/{userId}", consumes = {MediaType.APPLICATION_JSON_VALUE,
+      MediaType.MULTIPART_FORM_DATA_VALUE})
+  public BaseResponse<UserModifyResponse> updateUser(
+      @Positive @PathVariable Long userId,
+      @RequestPart(value = "image", required = false) MultipartFile image,
+      @Valid @RequestPart(value = "request") UserModifyRequest request) {
+
+    log.info("[updateUser] 유저 정보 변경 요청");
+    return BaseResponse.success(
+        SUCCESS_UPDATE_USER,
+        userService.updateUser(userId, image, request)
+    );
+  }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/org/jnjeaaaat/onbition/common/MockImage.java
+++ b/src/test/java/org/jnjeaaaat/onbition/common/MockImage.java
@@ -1,0 +1,23 @@
+package org.jnjeaaaat.onbition.common;
+
+import org.springframework.mock.web.MockMultipartFile;
+
+/**
+ * 공통적으로 쓰이는 MockImage
+ */
+public class MockImage {
+
+  public static MockMultipartFile getImageFile() {
+    String fileName = "testImage";
+    String contentType = "png"; //파일타입
+
+    // Mock파일생성
+    return new MockMultipartFile(
+        "multipartFile",
+        fileName + "." + contentType,
+        contentType,
+        "<<data>>".getBytes()
+    );
+  }
+
+}

--- a/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUser.java
+++ b/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUser.java
@@ -1,0 +1,14 @@
+package org.jnjeaaaat.onbition.config;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+/**
+ * token 권한이 필요한 test method 에 적용하는 Annotation
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+  String uid() default "testId";
+}

--- a/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,29 @@
+package org.jnjeaaaat.onbition.config;
+
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+/**
+ * security config 와의 의존성을 깨고 test 할때만 사용하게되는 SecurityContext 재설정 class
+ */
+public class WithCustomMockUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithCustomMockUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+    String email = annotation.uid();
+
+    Authentication auth = new UsernamePasswordAuthenticationToken(email, "",
+        List.of(new SimpleGrantedAuthority("ROLE_VIEWER")));
+
+    SecurityContext context = SecurityContextHolder.getContext();
+    context.setAuthentication(auth);
+
+    return context;
+  }
+}

--- a/src/test/java/org/jnjeaaaat/onbition/service/impl/SignServiceImplTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/service/impl/SignServiceImplTest.java
@@ -14,6 +14,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -64,7 +65,7 @@ class SignServiceImplTest {
 
   @Test
   @DisplayName("[service] 회원가입 성공")
-  void success_register() {
+  void success_register() throws IOException {
     //given
     BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     MockMultipartFile image = getImageFile();

--- a/src/test/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImplTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImplTest.java
@@ -1,0 +1,218 @@
+package org.jnjeaaaat.onbition.service.impl.user;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.DUPLICATED_USER_NAME;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_USER;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NO_AUTHORITY;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SAME_PASSWORD;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UN_MATCH_PASSWORD;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UN_MATCH_PHONE_NUM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import org.jnjeaaaat.onbition.common.MockImage;
+import org.jnjeaaaat.onbition.domain.dto.user.PasswordModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.ResetPasswordRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.repository.TokenRepository;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.exception.BaseException;
+import org.jnjeaaaat.onbition.service.impl.ProfileImageServiceImpl;
+import org.jnjeaaaat.onbition.util.JwtTokenUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private TokenRepository tokenRepository;
+
+  @Mock
+  private JwtTokenUtil jwtTokenUtil;
+
+  @Mock
+  private ProfileImageServiceImpl imageService;
+
+  @InjectMocks
+  private UserServiceImpl userService;
+
+  @Spy
+  private BCryptPasswordEncoder passwordEncoder;
+
+  @Test
+  @DisplayName("[service] 유저 정보 변경 성공")
+  void success_update_user() {
+    //given
+    given(userRepository.findById(any()))
+        .willReturn(Optional.of(User.builder()
+                .id(1L)
+                .uid("testId")
+                .profileImgUrl("oldProfileImgUrl")
+                .name("oldName")
+                .build()
+            )
+        );
+    given(jwtTokenUtil.getUserIdFromToken())
+        .willReturn(1L);
+    given(imageService.saveImage(any(), any()))
+        .willReturn("newProfileImgUrl");
+
+    //when
+    UserModifyRequest request = UserModifyRequest.builder()
+        .name("newName")
+        .build();
+
+    UserModifyResponse response = userService.updateUser(
+        1L, MockImage.getImageFile(), request);
+
+    //then
+    assertEquals("newProfileImgUrl", response.getProfileImgUrl());
+    assertEquals("newName", response.getName());
+  }
+
+  @Test
+  @DisplayName("[service] 유저 정보 변경 실패 - 권한이 없는 토큰")
+  void failed_update_user_UN_MATCH_TOKEN() {
+    //given
+    given(jwtTokenUtil.getUserIdFromToken())
+        .willReturn(2L);
+    //when
+    BaseException exception = assertThrows(BaseException.class,
+        () -> userService.updateUser(1L, null, null));
+    //then
+    assertEquals(NO_AUTHORITY, exception.getStatus());
+  }
+
+  @Test
+  @DisplayName("[service] 유저 정보 변경 실패 - 없는 유저")
+  void failed_update_user_NOT_FOUND_USER() {
+    //given
+    given(jwtTokenUtil.getUserIdFromToken())
+        .willReturn(1L);
+    given(userRepository.findById(anyLong()))
+        .willReturn(Optional.empty());
+    //when
+    BaseException exception = assertThrows(BaseException.class,
+        () -> userService.updateUser(1L, null, null));
+    //then
+    assertEquals(NOT_FOUND_USER, exception.getStatus());
+  }
+
+  @Test
+  @DisplayName("[service] 유저 정보 변경 실패 - 중복된 이름")
+  void failed_update_user_DUPLICATED_NAME() {
+    //given
+    given(jwtTokenUtil.getUserIdFromToken())
+        .willReturn(1L);
+    given(userRepository.findById(anyLong()))
+        .willReturn(Optional.of(User.builder()
+            .id(1L)
+            .uid("firstUser")
+            .name("firstUserName")
+            .build()));
+    given(userRepository.existsByNameAndDeletedAtNull(anyString()))
+        .willReturn(true);
+
+    //when
+    UserModifyRequest request = UserModifyRequest.builder()
+        .name("secondUserName")
+        .build();
+
+    BaseException exception = assertThrows(BaseException.class,
+        () -> userService.updateUser(1L, null, request));
+
+    //then
+    assertEquals(DUPLICATED_USER_NAME, exception.getStatus());
+  }
+
+  @Test
+  @DisplayName("[service] 비밀번호 변경 실패 - 비밀번호 다름")
+  void failed_update_password_UN_MATCH_PASSWORD() {
+    //given
+    BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    given(jwtTokenUtil.getUserIdFromToken())
+        .willReturn(1L);
+    given(userRepository.findById(anyLong()))
+        .willReturn(Optional.of(User.builder()
+            .id(1L)
+            .uid("firstUser")
+            .name("firstUserName")
+            .password(passwordEncoder.encode("password"))
+            .build()));
+
+    //when
+    PasswordModifyRequest request =
+        new PasswordModifyRequest("wrongPassword", "newPassword");
+
+    BaseException exception = assertThrows(BaseException.class,
+        () -> userService.updatePassword(1L, request));
+
+    //then
+    assertEquals(UN_MATCH_PASSWORD, exception.getStatus());
+  }
+
+  @Test
+  @DisplayName("[service] 비밀번호 변경 실패 - 새 비밀번호와 같음")
+  void failed_update_password_SAME_PASSWORD() {
+    //given
+    BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    given(jwtTokenUtil.getUserIdFromToken())
+        .willReturn(1L);
+    given(userRepository.findById(anyLong()))
+        .willReturn(Optional.of(User.builder()
+            .id(1L)
+            .uid("firstUser")
+            .name("firstUserName")
+            .password(passwordEncoder.encode("originalPassword"))
+            .build()));
+
+    //when
+    PasswordModifyRequest request =
+        new PasswordModifyRequest("originalPassword", "originalPassword");
+
+    BaseException exception = assertThrows(BaseException.class,
+        () -> userService.updatePassword(1L, request));
+
+    //then
+    assertEquals(SAME_PASSWORD, exception.getStatus());
+  }
+
+  @Test
+  @DisplayName("[service] 비밀번호 초기화 실패 - 핸드폰 번호 다름")
+  void test() {
+    //given
+    given(userRepository.findByUidAndDeletedAtNull(anyString()))
+        .willReturn(Optional.of(User.builder()
+            .uid("firstUser")
+            .name("firstUserName")
+            .phone("010-1111-1111")
+            .build()));
+    //when
+    ResetPasswordRequest request =
+        new ResetPasswordRequest("firstUser", "010-2222-2222");
+    BaseException exception = assertThrows(BaseException.class,
+        () -> userService.resetPassword(request));
+
+    //then
+    assertEquals(UN_MATCH_PHONE_NUM, exception.getStatus());
+  }
+
+}

--- a/src/test/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImplTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
+import java.io.IOException;
 import java.util.Optional;
 import org.jnjeaaaat.onbition.common.MockImage;
 import org.jnjeaaaat.onbition.domain.dto.user.PasswordModifyRequest;
@@ -57,7 +58,7 @@ class UserServiceImplTest {
 
   @Test
   @DisplayName("[service] 유저 정보 변경 성공")
-  void success_update_user() {
+  void success_update_user() throws IOException {
     //given
     given(userRepository.findById(any()))
         .willReturn(Optional.of(User.builder()

--- a/src/test/java/org/jnjeaaaat/onbition/web/UserControllerTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/web/UserControllerTest.java
@@ -1,0 +1,97 @@
+package org.jnjeaaaat.onbition.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import org.jnjeaaaat.onbition.config.WithCustomMockUser;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.UserModifyResponse;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.service.impl.user.UserServiceImpl;
+import org.jnjeaaaat.onbition.util.JwtTokenUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+  @MockBean
+  private UserServiceImpl userService;
+
+  @MockBean
+  private UserRepository userRepository;
+
+  @MockBean
+  private JwtTokenUtil jwtTokenUtil;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithCustomMockUser
+  @DisplayName("[controller] 유저 정보 변경 성공")
+  void success_modify_user() throws Exception {
+    //given
+    final String fileName = "testImage";
+    final String contentType = "png"; //파일타입
+
+    //Mock파일생성
+    MockMultipartFile image = new MockMultipartFile(
+        "multipartFile",
+        fileName + "." + contentType,
+        contentType,
+        "<<data>>".getBytes()
+    );
+
+    // request builder
+    UserModifyRequest request =
+        UserModifyRequest.builder()
+            .name("newName")
+            .build();
+
+    String valueAsString = objectMapper.writeValueAsString(request);
+
+    given(userService.updateUser(anyLong(), any(), any()))
+        .willReturn(UserModifyResponse.builder()
+            .uid("testId")
+            .name("newName")
+            .profileImgUrl("newProfileImgUrl")
+            .build());
+
+    //when
+    //then
+    mockMvc.perform(multipart(HttpMethod.PUT, "/api/v1/user/1")
+            .file(image)
+            .file(new MockMultipartFile("request", "", "application/json",
+                valueAsString.getBytes(StandardCharsets.UTF_8)))
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .with(csrf())
+            .header("X-AUTH-TOKEN", "testAccessToken"))
+
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+
+}


### PR DESCRIPTION
Changes
---
1. UserController
   - 유저 정보 변경 `updateUser`
      - image 파일, 새로운 이름 Request
   - 패스워드 변경 `updatePassword`
      - 원래 비밀번호, 새로운 비밀번호 Request
   - 비밀번호 초기화 `resetPassword`
      - 로그인 하기 전 처리
      - securityConfig `permitAll()`
2. UserServiceImpl
   - updateUser
      - 토큰에 저장되어있는 userId 비교
      - 이미지가 null이 아니면 변경
         - S3에 저장되어있는 원래 이미지 삭제 후 새로운 이미지 저장
      - 원래 name과 다르다면 변경
   - updatePassword
      - PasswordEncoder로 비밀번호 비교 후 변경
      - 새로운 비밀번호와 같다면 변경 x
   - resetPassword
      - 핸드폰 번호가 다르면 초기화 x
      - validation이 통과되면 랜덤문자열 생성후 문자전송
      - 랜덤문자열로 db의 비밀번호 수정

Background
---
- 유저 정보 수정을 할때 비밀번호 변경은 별개로 생성해야 한다.
- 사용자가 비밀번호를 잊어버렸을때 초기화하는 api 필요

Discuss
---
test코드를 작성하는데 이전에 만들었던 api에는 필요없었던 accessToken 권한 확인이 발목을 잡았다.
임의로 권한을 만들어서 넣는다는 개념은 알겠는데 코드를 어떻게 짜야되는지 막막했다..

1. 새로운 토큰을 만들어 넣어보기도 하고,
2. `Authentication` 객체에 임의의 권한을 갖는 토큰을 지정해보기도 하고,
3. `UsernamePasswordAuthenticationToken` 객체도 이용해봤지만 모두 실패하고

참조링크를 따라 성공했다..!

Issues
---
Resolved: #26 #27 #28 #29

Reference
---
[API 테스트할때 Header의 AccessToken에 임의의 권한 추가](https://velog.io/@da_na/Spring-Security-JWT-Spring-Security-Controller-Unit-Test%ED%95%98%EA%B8%B0)