### PR TITLE
feat: [PAINTING-CREATE] 그림 등록

### DIFF
--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/AuthUser.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/AuthUser.java
@@ -1,0 +1,21 @@
+package org.jnjeaaaat.onbition.config.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * jwt 토큰으로부터 유저 정보를 받아오기 위한 annotation
+ */
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthUser {
+
+  boolean errorOnInvalidType() default false;
+
+  String expression() default "";
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/AuthUserArgumentResolver.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/AuthUserArgumentResolver.java
@@ -1,0 +1,59 @@
+package org.jnjeaaaat.onbition.config.annotation;
+
+import java.lang.annotation.Annotation;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * AuthUser annotation 구현체
+ */
+@Component
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return findMethodAnnotation(AuthUser.class, parameter) != null;
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null) {
+      return null;
+    }
+    Object principal = authentication.getPrincipal();
+    if (principal != null && !parameter.getParameterType().isAssignableFrom(principal.getClass())) {
+      AuthUser authPrincipal = findMethodAnnotation(AuthUser.class, parameter);
+      if (authPrincipal.errorOnInvalidType()) {
+        throw new ClassCastException(
+            principal + " is not assignable to " + parameter.getParameterType());
+      }
+      return null;
+    }
+    return principal;
+  }
+
+  private <T extends Annotation> T findMethodAnnotation(Class<T> annotationClass,
+      MethodParameter parameter) {
+    T annotation = parameter.getParameterAnnotation(annotationClass);
+    if (annotation != null) {
+      return annotation;
+    }
+    Annotation[] annotationsToSearch = parameter.getParameterAnnotations();
+    for (Annotation toSearch : annotationsToSearch) {
+      annotation = AnnotationUtils.findAnnotation(toSearch.annotationType(), annotationClass);
+      if (annotation != null) {
+        return annotation;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TagSize.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TagSize.java
@@ -1,0 +1,23 @@
+package org.jnjeaaaat.onbition.config.annotation.valid;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+
+/**
+ * 그림 태그 최대 사이즈 validation annotation
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TagSizeValidator.class)
+public @interface TagSize {
+
+  String message() default "태그는 10개까지만 입력할 수 있습니다.";
+
+  Class[] groups() default {};
+
+  Class[] payload() default {};
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TagSizeValidator.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TagSizeValidator.java
@@ -1,0 +1,17 @@
+package org.jnjeaaaat.onbition.config.annotation.valid;
+
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * 그림 태그 최대사이즈 annotation 구현체 class
+ */
+public class TagSizeValidator implements ConstraintValidator<TagSize, List<String>> {
+
+  @Override
+  public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+    return value.size() <= 10;
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TagSizeValidator.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TagSizeValidator.java
@@ -1,16 +1,16 @@
 package org.jnjeaaaat.onbition.config.annotation.valid;
 
-import java.util.List;
+import java.util.Set;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 /**
  * 그림 태그 최대사이즈 annotation 구현체 class
  */
-public class TagSizeValidator implements ConstraintValidator<TagSize, List<String>> {
+public class TagSizeValidator implements ConstraintValidator<TagSize, Set<String>> {
 
   @Override
-  public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+  public boolean isValid(Set<String> value, ConstraintValidatorContext context) {
     return value.size() <= 10;
   }
 

--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/Telephone.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/Telephone.java
@@ -1,4 +1,4 @@
-package org.jnjeaaaat.onbition.config.annotation;
+package org.jnjeaaaat.onbition.config.annotation.valid;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TelephoneValidator.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/annotation/valid/TelephoneValidator.java
@@ -1,7 +1,8 @@
-package org.jnjeaaaat.onbition.config.annotation;
+package org.jnjeaaaat.onbition.config.annotation.valid;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import org.jnjeaaaat.onbition.config.annotation.valid.Telephone;
 
 /**
  * @Telephone 어노테이션 구현체

--- a/src/main/java/org/jnjeaaaat/onbition/config/security/WebConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/security/WebConfig.java
@@ -1,0 +1,23 @@
+package org.jnjeaaaat.onbition.config.security;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jnjeaaaat.onbition.config.annotation.AuthUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * custom HandlerMethodArgumentResolver 등록을 위한 WebConfig class
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+  private final AuthUserArgumentResolver authUserArgumentResolver;
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(authUserArgumentResolver);
+  }
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/auth/UserDetailsImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/auth/UserDetailsImpl.java
@@ -30,7 +30,7 @@ public class UserDetailsImpl implements UserDetails {
     return user.getRoles()
         .stream()
         .map(SimpleGrantedAuthority::new)
-        .collect(Collectors.toList());
+        .collect(Collectors.toSet());
   }
 
   /*

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -36,6 +36,9 @@ public enum BaseStatus {
   SUCCESS_UPDATE_PASSWORD(true, OK.value(), "비밀번호가 변경되었습니다."),
   SUCCESS_RESET_PASSWORD(true, OK.value(), "비밀번호가 초기화 되었습니다."),
 
+  // painting
+  SUCCESS_CREATE_PAINTING(true, OK.value(), "그림을 등록하였습니다."),
+
 
 
   //////////////////////////////// failed response ////////////////////////////////
@@ -51,7 +54,6 @@ public enum BaseStatus {
   NEED_REPOST_PHONE_NUMBER(false, BAD_REQUEST.value(), "번호를 다시 입력해주세요."),
   UN_MATCH_VERIFICATION_CODE(false, BAD_REQUEST.value(), "인증번호가 일치하지 않습니다."),
 
-
   // auth
   ACCESS_TOKEN_EXPIRED_TOKEN(false, UNAUTHORIZED.value(), "만료된 토큰입니다. 재발급 요청해주세요."),
   REFRESH_TOKEN_EXPIRED_TOKEN(false, UNAUTHORIZED.value(), "다시 로그인해주세요"),
@@ -59,6 +61,9 @@ public enum BaseStatus {
   NOT_FOUND_TOKEN(false, UNAUTHORIZED.value(), "토큰이 존재하지 않습니다."),
   INVALID_TOKEN(false, UNAUTHORIZED.value(), "유효하지 않는 토큰입니다."),
   ALREADY_LOGOUT(false, UNAUTHORIZED.value(), "이미 로그아웃 상태입니다."),
+
+  // painting
+  UNDER_MIN_PRICE(false, BAD_REQUEST.value(), "판매되는 그림의 가격은 1000원 이상이어야 합니다."),
 
 
   // file

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputRequest.java
@@ -1,0 +1,39 @@
+package org.jnjeaaaat.onbition.domain.dto.paint;
+
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.config.annotation.valid.TagSize;
+
+/**
+ * 그림 등록 Request class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaintingInputRequest {
+
+  @NotBlank(message = "제목을 입력해주세요")
+  private String title;
+
+  @Size(min = 10, max = 300)
+  private String description;  // 그림 설명
+
+  @NotNull
+  private Boolean isSale;     // 그림 판매 여부
+
+  private Long auctionPrice;    // 경매 시작 가격
+  private Long salePrice;   // 매매 가격
+
+  @TagSize
+  private List<String> tags;    // tags 리스트
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputRequest.java
@@ -1,6 +1,6 @@
 package org.jnjeaaaat.onbition.domain.dto.paint;
 
-import java.util.List;
+import java.util.Set;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -34,6 +34,6 @@ public class PaintingInputRequest {
   private Long salePrice;   // 매매 가격
 
   @TagSize
-  private List<String> tags;    // tags 리스트
+  private Set<String> tags;    // tags 리스트
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
@@ -1,7 +1,7 @@
 package org.jnjeaaaat.onbition.domain.dto.paint;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +28,7 @@ public class PaintingInputResponse {
   private Boolean isSale;     // 그림 판매 여부
   private Long auctionPrice;    // 경매 시작 가격
   private Long salePrice;   // 매매 가격
-  private List<String> tags;    // tags 리스트
+  private Set<String> tags;    // tags 리스트
   private LocalDateTime createdAt;    // 그림 생성 시각
 
   public static PaintingInputResponse from(Painting painting) {

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
@@ -1,0 +1,49 @@
+package org.jnjeaaaat.onbition.domain.dto.paint;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+
+/**
+ * 그림 등록 Response class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaintingInputResponse {
+
+  private Long paintingId;    // 그림 PK
+  private SimpleUserDto user;   // 그림 소유자
+  private String paintingImgUrl;    // 그림 url
+  private String title;   // 그림 제목
+  private String description;  // 그림 설명
+  private Boolean isSale;     // 그림 판매 여부
+  private Long auctionPrice;    // 경매 시작 가격
+  private Long salePrice;   // 매매 가격
+  private List<String> tags;    // tags 리스트
+  private LocalDateTime createdAt;    // 그림 생성 시각
+
+  public static PaintingInputResponse from(Painting painting) {
+    return PaintingInputResponse.builder()
+        .paintingId(painting.getId())
+        .user(SimpleUserDto.from(painting.getUser()))
+        .paintingImgUrl(painting.getPaintingImgUrl())
+        .title(painting.getTitle())
+        .description(painting.getDescription())
+        .isSale(painting.isSale())
+        .auctionPrice(painting.getAuctionPrice())
+        .salePrice(painting.getSalePrice())
+        .tags(painting.getTags())
+        .createdAt(painting.getCreatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignInResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignInResponse.java
@@ -1,6 +1,6 @@
 package org.jnjeaaaat.onbition.domain.dto.sign;
 
-import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +21,7 @@ public class SignInResponse {
 
   private Long id;  // 유저 PK
   private String uid;   // 유저 id
-  private List<String> roles;  // 유저 권한
+  private Set<String> roles;  // 유저 권한
   private String accessToken;  // accessToken
   private String refreshToken; // refreshToken
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignUpRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignUpRequest.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.jnjeaaaat.onbition.config.annotation.Telephone;
+import org.jnjeaaaat.onbition.config.annotation.valid.Telephone;
 
 /**
  * 회원가입에 필요한 Request class

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignUpResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/sign/SignUpResponse.java
@@ -1,6 +1,6 @@
 package org.jnjeaaaat.onbition.domain.dto.sign;
 
-import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +22,7 @@ public class SignUpResponse {
   private String profileImgUrl;  // 유저 프로필사진 Url
   private String uid;   // 유저 id
   private String name;  // 유저 이름
-  private List<String> roles;   // 유저 권한 목록
+  private Set<String> roles;   // 유저 권한 목록
 
   public static SignUpResponse from(UserDto userDto) {
     return SignUpResponse.builder()

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/ResetPasswordRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/ResetPasswordRequest.java
@@ -4,7 +4,7 @@ import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.jnjeaaaat.onbition.config.annotation.Telephone;
+import org.jnjeaaaat.onbition.config.annotation.valid.Telephone;
 
 /**
  * 비밀번호 초기화 Request class

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/SimpleUserDto.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/SimpleUserDto.java
@@ -1,0 +1,36 @@
+package org.jnjeaaaat.onbition.domain.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.entity.User;
+
+/**
+ * 다른 Entity return 값에 포함할 간단한 User 정보 class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SimpleUserDto {
+
+  private Long userId;
+  private String profileImgUrl;
+  private String uid;
+  private String name;
+  private String phone;
+
+  public static SimpleUserDto from(User user) {
+    return SimpleUserDto.builder()
+        .userId(user.getId())
+        .profileImgUrl(user.getProfileImgUrl())
+        .uid(user.getUid())
+        .name(user.getName())
+        .phone(user.getPhone())
+        .build();
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserDto.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/user/UserDto.java
@@ -1,7 +1,7 @@
 package org.jnjeaaaat.onbition.domain.dto.user;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +28,7 @@ public class UserDto {
   private String phone;     // 유저 핸드폰번호
   private String cardNum;   // 유저 카드번호
   private String accountNum;  // 유저 계좌번호
-  private List<String> roles; // 유저 권한
+  private Set<String> roles; // 유저 권한
 
   private LocalDateTime createdAt;  // 유저 생성 일자
   private LocalDateTime updatedAt;  // 유저정보 변경 일자

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/Painting.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/Painting.java
@@ -1,0 +1,69 @@
+package org.jnjeaaaat.onbition.domain.entity;
+
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+
+/**
+ * Painting Entity Class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@TypeDef(name = "json", typeClass = JsonType.class)
+/*
+ type name(식별자라고 이해하면됨) 을 "json"으로 지정
+ "json" -> JsonType.class 로 지정하라는 뜻.
+ */
+public class Painting extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;      // painting PK
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;    // 그림 소유자
+
+  @Column(nullable = false)
+  private String paintingImgUrl;    // 그림 url
+
+  @Column(nullable = false)
+  private String title;   // 그림 제목
+
+  @Column(nullable = false)
+  private String description;  // 그림 설명
+
+  @Column(nullable = false)
+  private boolean isSale;     // 그림 판매 여부
+
+  @Column(nullable = false)
+  private Long auctionPrice;    // 경매 시작 가격
+
+  @Column(nullable = false)
+  private Long salePrice;   // 매매 가격
+
+  @Type(type = "json")
+  @Column(columnDefinition = "json")
+  @Builder.Default
+  private List<String> tags = new ArrayList<>();    // tags 리스트
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/Painting.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/Painting.java
@@ -1,8 +1,8 @@
 package org.jnjeaaaat.onbition.domain.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonType;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -64,6 +64,6 @@ public class Painting extends BaseEntity {
   @Type(type = "json")
   @Column(columnDefinition = "json")
   @Builder.Default
-  private List<String> tags = new ArrayList<>();    // tags 리스트
+  private Set<String> tags = new HashSet<>();    // tags 리스트
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/User.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/User.java
@@ -6,11 +6,13 @@ import com.vladmihalcea.hibernate.type.json.JsonType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -69,4 +71,17 @@ public class User extends BaseEntity {
   @Builder.Default
   private List<String> roles = new ArrayList<>(); // 유저 권한 리스트
 
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<Painting> paintings = new ArrayList<>();
+
+  /*
+  유저 새로운 권한 추가 method
+   */
+  public void addRoles(String newRole) {
+    // 이미 권한이 있는게 아니면 추가
+    if (!this.roles.stream().anyMatch(s -> s.equals(newRole))) {
+      this.roles.add(newRole);
+    }
+  }
 }

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/User.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/User.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.vladmihalcea.hibernate.type.json.JsonType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -69,7 +71,7 @@ public class User extends BaseEntity {
   @Type(type = "json") // TypeDef 를 통해 선언한 "json" Type 적용
   @Column(columnDefinition = "json") // MySQL column 도 "json" 적용
   @Builder.Default
-  private List<String> roles = new ArrayList<>(); // 유저 권한 리스트
+  private Set<String> roles = new HashSet<>(); // 유저 권한 리스트
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
@@ -78,10 +80,7 @@ public class User extends BaseEntity {
   /*
   유저 새로운 권한 추가 method
    */
-  public void addRoles(String newRole) {
-    // 이미 권한이 있는게 아니면 추가
-    if (!this.roles.stream().anyMatch(s -> s.equals(newRole))) {
-      this.roles.add(newRole);
-    }
+  public boolean addRoles(String newRole) {
+    return this.roles.add(newRole);
   }
 }

--- a/src/main/java/org/jnjeaaaat/onbition/domain/repository/PaintingRepository.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/repository/PaintingRepository.java
@@ -1,0 +1,13 @@
+package org.jnjeaaaat.onbition.domain.repository;
+
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Painting DB 접근 Repository
+ */
+@Repository
+public interface PaintingRepository extends JpaRepository<Painting, Long> {
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/PaintingService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/PaintingService.java
@@ -1,0 +1,17 @@
+package org.jnjeaaaat.onbition.service;
+
+import java.io.IOException;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 그림 등록, 수정, 조회 service interface
+ */
+public interface PaintingService {
+
+  // 새로운 그림 등록
+  PaintingInputResponse createPainting(String uid, MultipartFile image, PaintingInputRequest request)
+      throws IOException;
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/ImageServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/ImageServiceImpl.java
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ProfileImageServiceImpl implements ImageService {
+public class ImageServiceImpl implements ImageService {
   private final FileService fileService;
 
   /*

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/auth/SignServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/auth/SignServiceImpl.java
@@ -80,7 +80,7 @@ public class SignServiceImpl implements SignService {
                 .profileImgUrl(imageUrl)  // image Url 저장 (http://...)
                 .name(request.getName())  // 유저 이름
                 .phone(request.getPhone()) // 유저 핸드포 번호
-                .roles(Collections.singletonList("ROLE_VIEWER")) // 기본 권한 VIEWER
+                .roles(Collections.singleton("ROLE_VIEWER")) // 기본 권한 VIEWER
                 .build()
             )
         )

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
@@ -1,0 +1,73 @@
+package org.jnjeaaaat.onbition.service.impl.paint;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_USER;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UNDER_MIN_PRICE;
+
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.repository.PaintingRepository;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.exception.BaseException;
+import org.jnjeaaaat.onbition.service.ImageService;
+import org.jnjeaaaat.onbition.service.PaintingService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 그림 등록, 수정, 조회 service interface 구현체 class
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaintingServiceImpl implements PaintingService {
+
+  private final UserRepository userRepository;
+  private final PaintingRepository paintingRepository;
+  private final ImageService imageService;
+
+  private final String DREAMER = "ROLE_DREAMER";
+
+  @Override
+  @Transactional
+  public PaintingInputResponse createPainting(String uid, MultipartFile image,
+      PaintingInputRequest request) throws IOException {
+
+    log.info("[createPainting]");
+
+    User user = userRepository.findByUidAndDeletedAtNull(uid)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+
+    // isSale이 true인데 가격이 1000원 미만일때
+    if (request.getIsSale()) {
+      if (request.getAuctionPrice() < 1000L || request.getSalePrice() < 1000L) {
+        throw new BaseException(UNDER_MIN_PRICE);
+      }
+    }
+
+    // user 권한 "DREAMER" 추가
+    user.addRoles(DREAMER);
+
+    // 사진 저장 후 url 가져오기
+    String imageUrl = imageService.saveImage(image, FileFolder.PAINT_IMAGE);
+
+    return PaintingInputResponse.from(
+        paintingRepository.save(Painting.builder()
+            .user(user)
+            .paintingImgUrl(imageUrl)
+            .title(request.getTitle())
+            .description(request.getDescription())
+            .isSale(request.getIsSale())
+            .auctionPrice(request.getAuctionPrice())
+            .salePrice(request.getSalePrice())
+            .tags(request.getTags())
+            .build())
+    );
+  }
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
@@ -34,21 +34,24 @@ public class PaintingServiceImpl implements PaintingService {
 
   private final String DREAMER = "ROLE_DREAMER";
 
+  /*
+  [그림 등록]
+  Request: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트
+  Response: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트, 등록한 시간
+   */
   @Override
   @Transactional
   public PaintingInputResponse createPainting(String uid, MultipartFile image,
       PaintingInputRequest request) throws IOException {
 
-    log.info("[createPainting]");
+    log.info("[createPainting] 그림 등록");
 
     User user = userRepository.findByUidAndDeletedAtNull(uid)
         .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
 
     // isSale이 true인데 가격이 1000원 미만일때
-    if (request.getIsSale()) {
-      if (request.getAuctionPrice() < 1000L || request.getSalePrice() < 1000L) {
-        throw new BaseException(UNDER_MIN_PRICE);
-      }
+    if (request.getIsSale() && (request.getAuctionPrice() < 1000L || request.getSalePrice() < 1000L)) {
+      throw new BaseException(UNDER_MIN_PRICE);
     }
 
     // user 권한 "DREAMER" 추가

--- a/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
@@ -39,10 +39,10 @@ public class PaintingController {
       MediaType.MULTIPART_FORM_DATA_VALUE})
   public BaseResponse<PaintingInputResponse> createPainting(
       @AuthUser UserDetails userDetails,
-      @RequestPart(value = "image") MultipartFile image,
+      @RequestPart(value = "image", required = false) MultipartFile image,
       @Valid @RequestPart(value = "request") PaintingInputRequest request) throws IOException {
 
-    log.info("[createPaint] 그림 추가 요청");
+    log.info("[createPaint] 그림 등록 요청");
 
     return BaseResponse.success(
         SUCCESS_CREATE_PAINTING,

--- a/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
@@ -1,0 +1,54 @@
+package org.jnjeaaaat.onbition.web;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_CREATE_PAINTING;
+
+import java.io.IOException;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.config.annotation.AuthUser;
+import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.service.PaintingService;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 그림 등록, 그림 수정, 그림 조회 api
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/paintings")
+public class PaintingController {
+
+  private final PaintingService paintingService;
+
+  /*
+  [그림 등록]
+  Request: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트
+  Response: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트, 등록한 시간
+   */
+  @PostMapping(value = "", consumes = {MediaType.APPLICATION_JSON_VALUE,
+      MediaType.MULTIPART_FORM_DATA_VALUE})
+  public BaseResponse<PaintingInputResponse> createPainting(
+      @AuthUser UserDetails userDetails,
+      @RequestPart(value = "image") MultipartFile image,
+      @Valid @RequestPart(value = "request") PaintingInputRequest request) throws IOException {
+
+    log.info("[createPaint] 그림 추가 요청");
+
+    return BaseResponse.success(
+        SUCCESS_CREATE_PAINTING,
+        paintingService.createPainting(userDetails.getUsername(), image, request)
+    );
+
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/web/SMSController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/SMSController.java
@@ -6,7 +6,7 @@ import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_SEND_TEX
 import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jnjeaaaat.onbition.config.annotation.Telephone;
+import org.jnjeaaaat.onbition.config.annotation.valid.Telephone;
 import org.jnjeaaaat.onbition.domain.dto.auth.SendTextResponse;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
 import org.jnjeaaaat.onbition.service.SMSService;

--- a/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUser.java
+++ b/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUser.java
@@ -10,5 +10,9 @@ import org.springframework.security.test.context.support.WithSecurityContext;
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
 public @interface WithCustomMockUser {
+
   String uid() default "testId";
+
+  String role() default "ROLE_VIEWER";
+
 }

--- a/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/org/jnjeaaaat/onbition/config/WithCustomMockUserSecurityContextFactory.java
@@ -1,11 +1,14 @@
 package org.jnjeaaaat.onbition.config;
 
-import java.util.List;
+import java.util.Set;
+import org.jnjeaaaat.onbition.domain.dto.auth.UserDetailsImpl;
+import org.jnjeaaaat.onbition.domain.entity.User;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
 /**
@@ -16,10 +19,15 @@ public class WithCustomMockUserSecurityContextFactory implements
 
   @Override
   public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
-    String email = annotation.uid();
+    String uid = annotation.uid();
+    String role = annotation.role();
 
-    Authentication auth = new UsernamePasswordAuthenticationToken(email, "",
-        List.of(new SimpleGrantedAuthority("ROLE_VIEWER")));
+    UserDetails userDetails = new UserDetailsImpl(User.builder()
+        .uid(uid)
+        .build());
+
+    Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "password",
+        Set.of(new SimpleGrantedAuthority(role)));
 
     SecurityContext context = SecurityContextHolder.getContext();
     context.setAuthentication(auth);

--- a/src/test/java/org/jnjeaaaat/onbition/service/impl/SignServiceImplTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/service/impl/SignServiceImplTest.java
@@ -15,9 +15,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignInRequest;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignUpRequest;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignUpResponse;
@@ -71,7 +70,7 @@ class SignServiceImplTest {
     MockMultipartFile image = getImageFile();
 
     // role list
-    List<String> roleList = Arrays.asList("ROLE_VIEWER");
+    Set<String> roleSet = Set.of("ROLE_VIEWER");
 
     // request
     SignUpRequest request = SignUpRequest.builder()
@@ -87,7 +86,7 @@ class SignServiceImplTest {
             .password(passwordEncoder.encode("password")) // 암호화된 비밀번호 저장
             .profileImgUrl("https://onbition/jnjeaaaat/org")
             .name("testName")
-            .roles(roleList)
+            .roles(roleSet)
             .phone("010-1234-1334")
             .build());
 
@@ -169,13 +168,13 @@ class SignServiceImplTest {
   @DisplayName("[service] 토큰 생성 성공")
   void success_create_token() {
     //given
-    List<String> roleList = Arrays.asList("ROLE_VIEWER");
+    Set<String> roleSet = Set.of("ROLE_VIEWER");
     User user = User.builder()
         .uid("testId")
         .password(passwordEncoder.encode("password")) // 암호화된 비밀번호 저장
         .profileImgUrl("https://onbition/jnjeaaaat/org")
         .name("testName")
-        .roles(roleList)
+        .roles(roleSet)
         .phone("010-1234-1334")
         .build();
 

--- a/src/test/java/org/jnjeaaaat/onbition/service/impl/SignServiceImplTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/service/impl/SignServiceImplTest.java
@@ -49,7 +49,7 @@ class SignServiceImplTest {
   private TokenRepository tokenRepository;
 
   @Mock
-  private ProfileImageServiceImpl imageService;
+  private ImageServiceImpl imageService;
 
   @Mock
   private JwtTokenUtil jwtTokenUtil;

--- a/src/test/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImplTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImplTest.java
@@ -1,0 +1,110 @@
+package org.jnjeaaaat.onbition.service.impl.paint;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UNDER_MIN_PRICE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.jnjeaaaat.onbition.common.MockImage;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.repository.PaintingRepository;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.exception.BaseException;
+import org.jnjeaaaat.onbition.service.impl.ImageServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaintingServiceImplTest {
+
+  @Mock
+  private ImageServiceImpl imageService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PaintingRepository paintingRepository;
+
+  @InjectMocks
+  private PaintingServiceImpl paintingService;
+
+  @Test
+  @DisplayName("[service] 그림 등록 성공")
+  void success_create_painting() throws IOException {
+    //given
+    Set<String> roleSet = new HashSet<>(List.of("ROLE_VIEWER"));
+    User user = User.builder()
+        .uid("testId")
+        .roles(roleSet)
+        .build();
+
+    given(userRepository.findByUidAndDeletedAtNull(anyString()))
+        .willReturn(Optional.of(user));
+
+    Set<String> tagSet = Set.of("tag1", "tag2", "tag3");
+    PaintingInputRequest request = PaintingInputRequest.builder()
+        .title("testTitle")
+        .description("testDescription")
+        .isSale(false)
+        .tags(tagSet)
+        .build();
+
+    given(paintingRepository.save(any()))
+        .willReturn(Painting.builder()
+            .user(user)
+            .paintingImgUrl("testPaintingImgUrl")
+            .title("testTitle")
+            .description("testDescription")
+            .isSale(false)
+            .auctionPrice(0L)
+            .salePrice(0L)
+            .tags(tagSet)
+            .build());
+
+    //when
+    PaintingInputResponse response = paintingService.createPainting("testId",
+        MockImage.getImageFile(), request);
+
+    //then
+    assertEquals("testTitle", response.getTitle());
+  }
+
+  @Test
+  @DisplayName("[service] 그림 등록 실패 - 최소 가격 미만")
+  void failed_create_painting_MIN_PRICE() {
+    //given
+    given(userRepository.findByUidAndDeletedAtNull(anyString()))
+        .willReturn(Optional.of(User.builder()
+            .uid("testId")
+            .build()));
+
+    //when
+    PaintingInputRequest request =
+        PaintingInputRequest.builder()
+            .isSale(true)
+            .auctionPrice(999L)
+            .salePrice(1000L)
+            .build();
+
+    BaseException exception = assertThrows(BaseException.class,
+        () -> paintingService.createPainting("testId", null, request));
+
+    //then
+    assertEquals(UNDER_MIN_PRICE, exception.getStatus());
+  }
+}

--- a/src/test/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImplTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/service/impl/user/UserServiceImplTest.java
@@ -24,7 +24,7 @@ import org.jnjeaaaat.onbition.domain.entity.User;
 import org.jnjeaaaat.onbition.domain.repository.TokenRepository;
 import org.jnjeaaaat.onbition.domain.repository.UserRepository;
 import org.jnjeaaaat.onbition.exception.BaseException;
-import org.jnjeaaaat.onbition.service.impl.ProfileImageServiceImpl;
+import org.jnjeaaaat.onbition.service.impl.ImageServiceImpl;
 import org.jnjeaaaat.onbition.util.JwtTokenUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,7 +48,7 @@ class UserServiceImplTest {
   private JwtTokenUtil jwtTokenUtil;
 
   @Mock
-  private ProfileImageServiceImpl imageService;
+  private ImageServiceImpl imageService;
 
   @InjectMocks
   private UserServiceImpl userService;

--- a/src/test/java/org/jnjeaaaat/onbition/web/PaintingControllerTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/web/PaintingControllerTest.java
@@ -1,0 +1,94 @@
+package org.jnjeaaaat.onbition.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import org.jnjeaaaat.onbition.common.MockImage;
+import org.jnjeaaaat.onbition.config.WithCustomMockUser;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.service.impl.paint.PaintingServiceImpl;
+import org.jnjeaaaat.onbition.util.JwtTokenUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@WebMvcTest(PaintingController.class)
+class PaintingControllerTest {
+
+  @MockBean
+  private PaintingServiceImpl paintingService;
+
+  @MockBean
+  private UserRepository userRepository;
+
+  @MockBean
+  private JwtTokenUtil jwtTokenUtil;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  @WithCustomMockUser
+  @DisplayName("[controller] 그림 등록 성공")
+  void success_create_painting() throws Exception {
+    //given
+    Set<String> tagSet = Set.of("tag1", "tag2", "tag3");
+    given(paintingService.createPainting(anyString(), any(), any()))
+        .willReturn(PaintingInputResponse.builder()
+            .paintingId(1L)
+            .title("testTitle")
+            .description("testDescription")
+            .tags(tagSet)
+            .build());
+
+    // request builder
+    PaintingInputRequest request =
+        PaintingInputRequest.builder()
+            .title("testTitle")
+            .description("testDescription")
+            .tags(tagSet)
+            .isSale(true)
+            .auctionPrice(1000L)
+            .salePrice(1000L)
+            .build();
+
+    String valueAsString = objectMapper.writeValueAsString(request);
+
+    //when
+    //then
+    mockMvc.perform(multipart("/api/v1/paintings")
+        .file(MockImage.getImageFile())
+        .file(new MockMultipartFile("request", "", "application/json",
+            valueAsString.getBytes(StandardCharsets.UTF_8)))
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .accept(MediaType.APPLICATION_JSON)
+        .characterEncoding("UTF-8")
+        .with(csrf())
+        .header("X-AUTH-TOKEN", "testAccessToken"))
+
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+
+}

--- a/src/test/java/org/jnjeaaaat/onbition/web/SignControllerTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/web/SignControllerTest.java
@@ -11,8 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 import org.jnjeaaaat.onbition.domain.dto.auth.ReissueResponse;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignInRequest;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignInResponse;
@@ -73,13 +72,13 @@ class SignControllerTest {
 
     String valueAsString = objectMapper.writeValueAsString(request);
 
-    List<String> roleList = Arrays.asList("ROLE_VIEWER");
+    Set<String> roleSet = Set.of("ROLE_VIEWER");
     given(signService.signUp(any(), any()))
         .willReturn(SignUpResponse.builder()
             .profileImgUrl("https://onbition/jnjeaaaat/org")
             .uid("testId")
             .name("testName")
-            .roles(roleList)
+            .roles(roleSet)
             .build());
 
     //when
@@ -107,11 +106,11 @@ class SignControllerTest {
   @DisplayName("[controller] 로그인 성공")
   void success_signIn() throws Exception {
     //given
-    List<String> roleList = Arrays.asList("ROLE_VIEWER");
+    Set<String> roleSet = Set.of("ROLE_VIEWER");
     given(signService.signIn(any()))
         .willReturn(SignInResponse.builder()
             .uid("testUid")
-            .roles(roleList)
+            .roles(roleSet)
             .accessToken("testAccessToken")
             .refreshToken("testRefreshToken")
             .build());


### PR DESCRIPTION
Changes
---
- Painting Entity 생성
   - User Entity와 다대일 양방향 연관관계
- Controller, Service
   - 회원등록 과 동일하게 그림 이미지 저장
   - 그림 등록하면 user 권한 추가 ROLE_DREAMER
      - 이미 추가된 권한이라면 추가 x
- Validation
   - 판매여부 false일때 경매가, 매매가 0원 가능
   - 판매여부 true일때 경매가, 매매가 최소 1000원
   - 태그 리스트 최대 10개까지만 등록 가능

Discuss
---
AuthenticationPrincipal 어노테이션을 어떨때 쓰는게 좋을지 고민이 됩니다.

예를 들면,
1. 그림 등록하는 유저에 대한 정보를 uri에 넣으면 한눈에 알아보기 불편해서 써도 될거같은데
2. 유저 정보 수정 api 같은 경우에는 어떤 유저에 대한 변경인지 PathVariable로 구분할 수 있게 하는게 좋을거 같은데
3. 유저 정보 수정 api 에도 AuthenticationPrincipal 어노테이션을 쓰는게 좋을까요?

Issues
---
Resolved: #31 #32 #33 #34