### PR TITLE
feat: [PAINT-ELASTICSEARCH] 그림 검색, 조회, 수정 with elasticsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,13 @@ out/
 out
 gen
 
+# log
 /logs
 
-
+# yml
 /src/main/resources/application-aws.yml
 /src/main/resources/application-mysql.yml
 /src/main/resources/application-secret.yml
+
+# querydsl
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.6'
@@ -63,6 +69,12 @@ dependencies {
     implementation 'org.hibernate.orm:hibernate-core:6.2.0.CR2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     runtimeOnly 'com.h2database:h2'
@@ -80,4 +92,22 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/doc/TROUBLE_SHOOTING.md
+++ b/doc/TROUBLE_SHOOTING.md
@@ -12,3 +12,8 @@
 
 ## ✨ ImmutableCollections 에러 해결
 ### [해결과정](https://jnjeaaaat.tistory.com/81)
+
+<br/>
+
+## ✨ test code csrf 문제 해결
+### [해결과정](https://jnjeaaaat.tistory.com/82)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+ARG ELK_VERSION
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
+RUN elasticsearch-plugin install analysis-nori

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
+    restart: always
     networks:
       - onbition
 
@@ -40,6 +41,7 @@ services:
       - "5601:5601"
     depends_on:
       - es-node-01
+    restart: always
     networks:
       - onbition
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.7'
+
+services:
+  es-node-01:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+        ELK_VERSION: 8.6.2
+    container_name: es-node-01
+    environment:
+      - cluster.name=es-docker-cluster
+      - node.name=es01
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 262144
+        hard: 262144
+    cap_add:
+      - IPC_LOCK
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    networks:
+      - onbition
+
+  kibana:
+    container_name: kibana
+    image: docker.elastic.co/kibana/kibana:8.6.2
+    environment:
+      ELASTICSEARCH_URL: http://es-node-01:9200
+      ELASTICSEARCH_HOSTS: http://es-node-01:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - es-node-01
+    networks:
+      - onbition
+
+volumes:
+  data01:
+    driver: local
+
+networks:
+  onbition:
+    driver: bridge

--- a/src/main/java/org/jnjeaaaat/onbition/config/ElasticSearchConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/ElasticSearchConfig.java
@@ -1,13 +1,11 @@
 package org.jnjeaaaat.onbition.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 @EnableElasticsearchRepositories
-@ConfigurationProperties(prefix = "spring.elasticsearch")
 @Configuration
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
 

--- a/src/main/java/org/jnjeaaaat/onbition/config/ElasticSearchConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/ElasticSearchConfig.java
@@ -1,0 +1,21 @@
+package org.jnjeaaaat.onbition.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@EnableElasticsearchRepositories
+@ConfigurationProperties(prefix = "spring.elasticsearch")
+@Configuration
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+  @Override
+  public ClientConfiguration clientConfiguration() {
+    return ClientConfiguration.builder()
+        .connectedTo("localhost:9200")
+        .build();
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/config/QueryDslConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.jnjeaaaat.onbition.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private  EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(){
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -38,6 +38,8 @@ public enum BaseStatus {
 
   // painting
   SUCCESS_CREATE_PAINTING(true, OK.value(), "그림을 등록하였습니다."),
+  SUCCESS_SEARCH_PAINTING(true, OK.value(), "그림을 조회하였습니다."),
+  SUCCESS_SEARCH_PAINTINGS_BY_TITLE(true, OK.value(), "제목으로 그림을 검색하였습니다."),
 
 
 
@@ -65,6 +67,9 @@ public enum BaseStatus {
   // painting
   UNDER_MIN_PRICE(false, BAD_REQUEST.value(), "판매되는 그림의 가격은 1000원 이상이어야 합니다."),
   NOT_FOUND_PAINTING(false, BAD_REQUEST.value(), "해당 그림이 없습니다."),
+
+  // painting elasticsearch
+  WRONG_PRICE_RANGE(false, BAD_REQUEST.value(), "최소금액이 최대금액보다 클 수 없습니다."),
 
 
   // file

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -40,6 +40,8 @@ public enum BaseStatus {
   SUCCESS_CREATE_PAINTING(true, OK.value(), "그림을 등록하였습니다."),
   SUCCESS_SEARCH_PAINTING(true, OK.value(), "그림을 조회하였습니다."),
   SUCCESS_SEARCH_PAINTINGS_BY_TITLE(true, OK.value(), "제목으로 그림을 검색하였습니다."),
+  SUCCESS_MODIFY_PAINTING_TAGS(true, OK.value(), "태그를 수정하였습니다."),
+  SUCCESS_CONVERT_TO_SALE(true, OK.value(), "그림 판매를 시작합니다."),
 
 
 
@@ -67,6 +69,7 @@ public enum BaseStatus {
   // painting
   UNDER_MIN_PRICE(false, BAD_REQUEST.value(), "판매되는 그림의 가격은 1000원 이상이어야 합니다."),
   NOT_FOUND_PAINTING(false, BAD_REQUEST.value(), "해당 그림이 없습니다."),
+  UN_MATCH_USER(false, BAD_REQUEST.value(), "그림의 소유자만 변경할 수 있습니다."),
 
   // painting elasticsearch
   WRONG_PRICE_RANGE(false, BAD_REQUEST.value(), "최소금액이 최대금액보다 클 수 없습니다."),

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/page/CustomPageRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/page/CustomPageRequest.java
@@ -1,0 +1,46 @@
+package org.jnjeaaaat.onbition.domain.dto.page;
+
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+/**
+ * Paging 처리를 위한 custom Page Request class
+ * page Number, page size, Sort direction (DESC, ASC), sort field 설정
+ * 판매중인 그림 여부, 최소가격, 최대가격 설정
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CustomPageRequest {
+
+  @PositiveOrZero
+  private Integer page;
+  @Positive
+  private Integer size;
+  private Sort.Direction direction;
+  private String sort;
+
+  private Boolean onlySale;
+  private Long minPrice;
+  private Long maxPrice;
+
+  // Sort Option
+  public Sort getSortOption() {
+    // 아무것도 설정하지 않았을때는 생성날짜 내림차순 정렬
+    Sort sortOption = Sort.by(Direction.DESC, "createdAt");
+
+    if (direction != null && !sort.isEmpty()) {
+      sortOption = Sort.by(direction, sort);
+    }
+
+    return sortOption;
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/page/OnlySalePageDto.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/page/OnlySalePageDto.java
@@ -1,0 +1,28 @@
+package org.jnjeaaaat.onbition.domain.dto.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 판매중인 그림 최소가격, 최대가격 설정 dto class
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OnlySalePageDto {
+
+  private Boolean onlySale;
+  private Long minPrice;
+  private Long maxPrice;
+
+  public static OnlySalePageDto of(CustomPageRequest customPageRequest) {
+    return OnlySalePageDto.builder()
+        .onlySale(customPageRequest.getOnlySale())
+        .minPrice(customPageRequest.getMinPrice())
+        .maxPrice(customPageRequest.getMaxPrice())
+        .build();
+  }
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
-import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.jnjeaaaat.onbition.domain.entity.Painting;
 
 /**
@@ -31,6 +30,7 @@ public class PaintingInputResponse {
   private Long salePrice;   // 매매 가격
   private Set<String> tags;    // tags 리스트
   private LocalDateTime createdAt;    // 그림 생성 시각
+  private LocalDateTime updatedAt;
 
   public static PaintingInputResponse from(Painting painting) {
     return PaintingInputResponse.builder()
@@ -39,11 +39,12 @@ public class PaintingInputResponse {
         .paintingImgUrl(painting.getPaintingImgUrl())
         .title(painting.getTitle())
         .description(painting.getDescription())
-        .isSale(painting.isSale())
+        .isSale(painting.getIsSale())
         .auctionPrice(painting.getAuctionPrice())
         .salePrice(painting.getSalePrice())
         .tags(painting.getTags())
         .createdAt(painting.getCreatedAt())
+        .updatedAt(painting.getUpdatedAt())
         .build();
   }
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingModifyPriceRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingModifyPriceRequest.java
@@ -1,0 +1,20 @@
+package org.jnjeaaaat.onbition.domain.dto.paint;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 그림 가격 변경 request class
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaintingModifyPriceRequest {
+
+  private Long auctionPrice;   // 경매가
+  private Long salePrice;     // 매매가
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingModifyTagsRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingModifyTagsRequest.java
@@ -1,0 +1,20 @@
+package org.jnjeaaaat.onbition.domain.dto.paint;
+
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 그림 태그 변경 request class
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaintingModifyTagsRequest {
+
+  private Set<String> tags;
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/ElasticSearchPainting.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/ElasticSearchPainting.java
@@ -1,0 +1,80 @@
+package org.jnjeaaaat.onbition.domain.entity;
+
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
+
+/**
+ * ElasticSearch Painting Document class
+ */
+@Document(indexName = "paintings", writeTypeHint = WriteTypeHint.FALSE)
+@Setting(settingPath = "/elasticsearch/painting-setting.json")
+@Mapping(mappingPath = "/elasticsearch/painting-mapping.json")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Slf4j
+public class ElasticSearchPainting {
+
+  @Id
+  private Long id;
+  private SimpleUserDto user;
+
+  @Field(type = FieldType.Text, name = "paintingImgUrl")
+  private String paintingImgUrl;    // 그림 url
+
+  @Field(type = FieldType.Keyword, name = "title")
+  private String title;   // 그림 제목
+
+  @Field(type = FieldType.Keyword, name = "description")
+  private String description;  // 그림 설명
+
+  @Field(type = FieldType.Boolean, name = "isSale")
+  private Boolean isSale;     // 그림 판매 여부
+
+  @Field(type = FieldType.Long, name = "auctionPrice")
+  private Long auctionPrice;    // 경매 시작 가격
+
+  @Field(type = FieldType.Long, name = "salePrice")
+  private Long salePrice;   // 매매 가격
+
+  @Field(type = FieldType.Text, name = "tags")
+  private Set<String> tags;  // 그림 태그
+
+  @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+  private LocalDateTime createdAt;
+  @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+  private LocalDateTime updatedAt;
+
+  public static ElasticSearchPainting from(Painting painting) {
+    return ElasticSearchPainting.builder()
+        .id(painting.getId())
+        .user(SimpleUserDto.from(painting.getUser()))
+        .paintingImgUrl(painting.getPaintingImgUrl())
+        .title(painting.getTitle())
+        .description(painting.getDescription())
+        .isSale(painting.isSale())
+        .auctionPrice(painting.getAuctionPrice())
+        .salePrice(painting.getSalePrice())
+        .tags(painting.getTags())
+        .createdAt(painting.getCreatedAt())
+        .updatedAt(painting.getUpdatedAt())
+        .build();
+
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/ElasticSearchPainting.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/ElasticSearchPainting.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
@@ -24,6 +25,7 @@ import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
 @Setting(settingPath = "/elasticsearch/painting-setting.json")
 @Mapping(mappingPath = "/elasticsearch/painting-mapping.json")
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -67,7 +69,7 @@ public class ElasticSearchPainting {
         .paintingImgUrl(painting.getPaintingImgUrl())
         .title(painting.getTitle())
         .description(painting.getDescription())
-        .isSale(painting.isSale())
+        .isSale(painting.getIsSale())
         .auctionPrice(painting.getAuctionPrice())
         .salePrice(painting.getSalePrice())
         .tags(painting.getTags())

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/Painting.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/Painting.java
@@ -47,7 +47,7 @@ public class Painting extends BaseEntity {
   private String description;  // 그림 설명
 
   @Column(nullable = false)
-  private boolean isSale;     // 그림 판매 여부
+  private Boolean isSale;     // 그림 판매 여부
 
   @Column(nullable = false)
   private Long auctionPrice;    // 경매 시작 가격

--- a/src/main/java/org/jnjeaaaat/onbition/domain/repository/ElasticSearchPaintingRepository.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/repository/ElasticSearchPaintingRepository.java
@@ -1,0 +1,26 @@
+package org.jnjeaaaat.onbition.domain.repository;
+
+import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * ElasticSearch Painting 접근 Repository
+ */
+@Repository
+public interface ElasticSearchPaintingRepository extends
+    ElasticsearchRepository<ElasticSearchPainting, Long> {
+
+  // 제목 또는 태그로 검색
+  Page<ElasticSearchPainting> findByTitleOrTags(String title, String tag, Pageable pageable);
+
+  // 제목으로 검색 (판매중인 그림 가격 범위 설정 x)
+  Page<ElasticSearchPainting> findByTitleAndIsSaleTrue(String title, Pageable pageable);
+
+  // 제목으로 검색 (판매중인 그림 가격 범위 설정)
+  Page<ElasticSearchPainting> findByTitleAndSalePriceBetween(String title, Long minPrice,
+      Long maxPrice, Pageable pageable);
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/PaintingService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/PaintingService.java
@@ -1,8 +1,12 @@
 package org.jnjeaaaat.onbition.service;
 
 import java.io.IOException;
+import org.jnjeaaaat.onbition.domain.dto.page.OnlySalePageDto;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -15,6 +19,10 @@ public interface PaintingService {
       throws IOException;
 
   // 그림 하나 조회
-//  PaintingDetailResponse getPainting(String uid, Long paintingId);
+  ElasticSearchPainting getPainting(String uid, Long paintingId);
+
+  // 제목으로 검색
+  Slice<ElasticSearchPainting> searchPaintings(String keyword, Pageable pageable, OnlySalePageDto onlySalePageDto);
+
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/PaintingService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/PaintingService.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import org.jnjeaaaat.onbition.domain.dto.page.OnlySalePageDto;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingModifyPriceRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingModifyTagsRequest;
 import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,6 +25,12 @@ public interface PaintingService {
 
   // 제목으로 검색
   Slice<ElasticSearchPainting> searchPaintings(String keyword, Pageable pageable, OnlySalePageDto onlySalePageDto);
+
+  // 그림 태그 변경
+  PaintingInputResponse updatePaintingTags(String uid, Long paintingId, PaintingModifyTagsRequest request);
+
+  // 판매중인 그림으로 변환
+  PaintingInputResponse convertPaintingToSale(String uid, Long paintingId, PaintingModifyPriceRequest request);
 
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
@@ -126,7 +126,7 @@ public class PaintingServiceImpl implements PaintingService {
     }
 
     // 검색된 전체 그림을 조회할때
-    if (!onlySalePageDto.getOnlySale()) {
+    if (onlySalePageDto.getOnlySale() == false) {
       log.info("[searchPaintings] 판매중이 아닌 그림 조회");
       return elasticSearchPaintingRepository.findByTitleOrTags(keyword, keyword, pageable);
     }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
@@ -3,15 +3,20 @@ package org.jnjeaaaat.onbition.service.impl.paint;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_PAINTING;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_USER;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UNDER_MIN_PRICE;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UN_MATCH_USER;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.WRONG_PRICE_RANGE;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
 import org.jnjeaaaat.onbition.domain.dto.page.OnlySalePageDto;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingModifyPriceRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingModifyTagsRequest;
 import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.jnjeaaaat.onbition.domain.entity.Painting;
 import org.jnjeaaaat.onbition.domain.entity.User;
@@ -24,6 +29,7 @@ import org.jnjeaaaat.onbition.service.PaintingService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -45,7 +51,7 @@ public class PaintingServiceImpl implements PaintingService {
   /*
   [그림 등록]
   Request: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트
-  Response: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트, 등록한 시간
+  Response: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트, 등록한 시간, 변경 시간
    */
   @Override
   public PaintingInputResponse createPainting(String uid, MultipartFile image,
@@ -96,6 +102,7 @@ public class PaintingServiceImpl implements PaintingService {
    */
   @Override
   public ElasticSearchPainting getPainting(String uid, Long paintingId) {
+    log.info("[getPainting] 그림 하나 조회");
 
     return elasticSearchPaintingRepository.findById(
             paintingId)
@@ -142,6 +149,100 @@ public class PaintingServiceImpl implements PaintingService {
     return elasticSearchPaintingRepository.findByTitleAndSalePriceBetween(
         keyword, minPrice, maxPrice, pageable
     );
+
+  }
+
+  /*
+  [그림 태그 변경]
+  Request: user id, painting PK, Set tag
+  Response: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트, 등록한 시간, 변경 시간
+   */
+  @Override
+  @Transactional
+  public PaintingInputResponse updatePaintingTags(String uid, Long paintingId,
+      PaintingModifyTagsRequest request) {
+    log.info("[updatePaintingTags] 그림 정보 수정");
+    Painting painting = paintingRepository.findById(paintingId)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_PAINTING));
+
+    // 그림의 소유주와 접근 유저가 다를때
+    if (!Objects.equals(uid, painting.getUser().getUid())) {
+      throw new BaseException(UN_MATCH_USER);
+    }
+
+    // 원래 태그랑 다를때만 수정
+    if (!painting.getTags().equals(request.getTags())) {
+      log.info("[updatePaintingTags] tag 변경");
+      updateTag(painting, request.getTags());
+    }
+
+    return PaintingInputResponse.from(painting);
+  }
+
+  /*
+  [그림 판매 시작]
+  Request: user id, painting PK, auctionPrice, salePrice
+  Response: 등록하는 유저, 등록하는 그림 이미지, 제목, 설명, 판매여부, 경매가, 매매가, 태그 리스트, 등록한 시간, 변경 시간
+   */
+  @Override
+  @Transactional
+  public PaintingInputResponse convertPaintingToSale(String uid, Long paintingId,
+      PaintingModifyPriceRequest request) {
+
+    log.info("[convertPaintingToSale] 그림 판매 시작");
+    Painting painting = paintingRepository.findById(paintingId)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_PAINTING));
+
+    // 그림의 소유주와 접근 유저가 다를때
+    if (!Objects.equals(uid, painting.getUser().getUid())) {
+      throw new BaseException(UN_MATCH_USER);
+    }
+
+    // 가격이 1000원 보다 낮을때
+    if (request.getAuctionPrice() < 1000L || request.getSalePrice() < 1000L) {
+      throw new BaseException(UNDER_MIN_PRICE);
+    }
+
+    if (!painting.getIsSale()) {
+      log.info("[convertPaintingToSale] 가격 변경");
+      updatePrice(painting, request);
+    }
+
+    return PaintingInputResponse.from(painting);
+  }
+
+  // 그림 태그 변경 method
+  private void updateTag(Painting painting, Set<String> tags) {
+    log.info("[updateTag] db tag 변경 시작");
+    painting.setTags(tags);
+    log.info("[updateTag] db tag 변경 완료");
+
+    ElasticSearchPainting esPainting = elasticSearchPaintingRepository.findById(painting.getId())
+        .orElseThrow(() -> new BaseException(NOT_FOUND_PAINTING));
+
+    log.info("[updateTag] es tag 변경 시작");
+    esPainting.setTags(tags);
+    elasticSearchPaintingRepository.save(esPainting);
+    log.info("[updateTag] es tag 변경 완료");
+  }
+
+  // 그림 판매여부, 가격 변경 method
+  private void updatePrice(Painting painting, PaintingModifyPriceRequest request) {
+    log.info("[updatePrice] db price 변경 시작");
+    painting.setIsSale(true);
+    painting.setAuctionPrice(request.getAuctionPrice());
+    painting.setSalePrice(request.getSalePrice());
+    log.info("[updatePrice] db price 변경 완료");
+
+    ElasticSearchPainting esPainting = elasticSearchPaintingRepository.findById(painting.getId())
+        .orElseThrow(() -> new BaseException(NOT_FOUND_PAINTING));
+
+    log.info("[updateTag] es tag 변경 시작");
+    esPainting.setIsSale(true);
+    esPainting.setAuctionPrice(request.getAuctionPrice());
+    esPainting.setSalePrice(request.getSalePrice());
+    elasticSearchPaintingRepository.save(esPainting);
+    log.info("[updateTag] es tag 변경 완료");
 
   }
 

--- a/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
@@ -1,20 +1,34 @@
 package org.jnjeaaaat.onbition.web;
 
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_CREATE_PAINTING;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_SEARCH_PAINTING;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_SEARCH_PAINTINGS_BY_TITLE;
 
 import jakarta.validation.Valid;
 import java.io.IOException;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.config.annotation.AuthUser;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
+import org.jnjeaaaat.onbition.domain.dto.page.CustomPageRequest;
+import org.jnjeaaaat.onbition.domain.dto.page.OnlySalePageDto;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.jnjeaaaat.onbition.service.PaintingService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -51,18 +65,45 @@ public class PaintingController {
 
   }
 
-//  @GetMapping("/{paintingId}")
-//  public BaseResponse<PaintingDetailResponse> getPainting(
-//      @AuthUser UserDetails userDetails,
-//      @PathVariable Long paintingId) {
-//
-//    log.info("[getPainting] 그림 하나 조회 요청");
-//
-//    return BaseResponse.success(
-//        SUCCESS,
-//        paintingService.getPainting(userDetails.getUsername(), paintingId)
-//    );
-//  }
+  /*
+  [그림 하나 조회]
+  Request: user id, painting PK
+  Response: ElasticSearchPainting
+   */
+  @GetMapping("/{paintingId}")
+  public BaseResponse<ElasticSearchPainting> getPainting(
+      @AuthUser UserDetails userDetails,
+      @PathVariable Long paintingId) {
 
+    log.info("[getPainting] 그림 하나 조회 요청");
+
+    return BaseResponse.success(
+        SUCCESS_SEARCH_PAINTING,
+        paintingService.getPainting(userDetails.getUsername(), paintingId)
+    );
+  }
+
+  /*
+  [그림 제목으로 검색]
+  Request: keyword, paging option(sorting field, sorting direction), 판매여부, 최소가격, 최대가격
+  Response: ElasticSearchPainting Slice 로 반환
+   */
+  @GetMapping("/search")
+  public BaseResponse<Slice<ElasticSearchPainting>> searchPaintings(
+      @RequestParam(required = false) String keyword,  // keyword가 없을때 전체그림 조회
+      @Valid @RequestBody CustomPageRequest customPageRequest) {
+
+    // paging을 위한 page num, page size, sort option 설정
+    Pageable pageable = PageRequest.of(customPageRequest.getPage(), customPageRequest.getSize(),
+        customPageRequest.getSortOption());
+
+    // 판매중인 그림에 대한 data 저장
+    OnlySalePageDto onlySalePageDto = OnlySalePageDto.of(customPageRequest);
+
+    return BaseResponse.success(
+        SUCCESS_SEARCH_PAINTINGS_BY_TITLE,
+        paintingService.searchPaintings(keyword, pageable, onlySalePageDto)
+    );
+  }
 
 }

--- a/src/main/resources/elasticsearch/painting-mapping.json
+++ b/src/main/resources/elasticsearch/painting-mapping.json
@@ -1,0 +1,54 @@
+{
+  "properties": {
+    "id": {
+      "type": "keyword"
+    },
+    "user": {
+      "properties": {
+        "userId": {
+          "type": "long"
+        },
+        "name": {
+          "type": "text"
+        },
+        "profileImgUrl": {
+          "type": "text"
+        },
+        "uid": {
+          "type": "text"
+        }
+      }
+    },
+    "paintingImgUrl": {
+      "type": "text"
+    },
+    "title": {
+      "type": "text",
+      "analyzer": "nori"
+    },
+    "description": {
+      "type": "text",
+      "analyzer": "nori"
+    },
+    "isSale": {
+      "type": "boolean"
+    },
+    "auctionPrice": {
+      "type": "long"
+    },
+    "salePrice": {
+      "type": "long"
+    },
+    "tags": {
+      "type": "text",
+      "analyzer": "nori"
+    },
+    "createdAt": {
+      "type": "date"
+    },
+    "updatedAt": {
+      "type": "date"
+    }
+
+  }
+}

--- a/src/main/resources/elasticsearch/painting-setting.json
+++ b/src/main/resources/elasticsearch/painting-setting.json
@@ -1,0 +1,28 @@
+{
+  "analysis": {
+    "analyzer": {
+      "nori": {
+        "type": "custom",
+        "tokenizer": "nori_mixed",
+        "filter": [
+          "lowercase",
+          "my_pos_f"
+        ]
+      }
+    },
+    "filter": {
+      "my_pos_f": {
+        "type": "nori_part_of_speech",
+        "stoptags": [
+          "VCP"
+        ]
+      }
+    },
+    "tokenizer": {
+      "nori_mixed": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "mixed"
+      }
+    }
+  }
+}

--- a/src/test/java/org/jnjeaaaat/onbition/sms/SMSControllerTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/sms/SMSControllerTest.java
@@ -2,12 +2,14 @@ package org.jnjeaaaat.onbition.sms;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jnjeaaaat.onbition.config.WithCustomMockUser;
 import org.jnjeaaaat.onbition.domain.dto.auth.SendTextResponse;
 import org.jnjeaaaat.onbition.service.impl.auth.SMSServiceImpl;
 import org.jnjeaaaat.onbition.config.security.JwtTokenProvider;
@@ -37,6 +39,7 @@ class SMSControllerTest {
   ObjectMapper objectMapper;
 
   @Test
+  @WithCustomMockUser
   @DisplayName("[controller] 인증코드 전송")
   void send_message() throws Exception {
     //given
@@ -45,14 +48,17 @@ class SMSControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/sms?phone=010-1234-1234"))
+    mockMvc.perform(post("/api/v1/sms?phone=010-1234-1234")
+            .with(csrf()))
+
         .andDo(print())
-//        .andExpect(jsonPath("$.result.verificationCode").value("000000"))
+        .andExpect(jsonPath("$.result.verificationCode").value("000000"))
         .andExpect(status().isOk());
 
   }
 
   @Test
+  @WithCustomMockUser
   @DisplayName("[controller] 인증코드 인증")
   void authenticate_verificationCode() throws Exception {
     //given
@@ -61,12 +67,13 @@ class SMSControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/sms/authentication?phone=010-1234-1234&code=000000"))
+    mockMvc.perform(post("/api/v1/sms/authentication?phone=010-1234-1234&code=000000")
+            .with(csrf()))
+
         .andExpect(jsonPath("$.result").value("010-1234-1234"))
         .andExpect(status().isOk())
         .andDo(print());
   }
-
 
 
 }

--- a/src/test/java/org/jnjeaaaat/onbition/web/PaintingControllerTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/web/PaintingControllerTest.java
@@ -1,23 +1,33 @@
 package org.jnjeaaaat.onbition.web;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.jnjeaaaat.onbition.common.MockImage;
 import org.jnjeaaaat.onbition.config.WithCustomMockUser;
+import org.jnjeaaaat.onbition.config.security.JwtTokenProvider;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingModifyPriceRequest;
+import org.jnjeaaaat.onbition.domain.dto.paint.PaintingModifyTagsRequest;
+import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
+import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.jnjeaaaat.onbition.domain.repository.UserRepository;
 import org.jnjeaaaat.onbition.service.impl.paint.PaintingServiceImpl;
-import org.jnjeaaaat.onbition.config.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,14 +87,114 @@ class PaintingControllerTest {
     //when
     //then
     mockMvc.perform(multipart("/api/v1/paintings")
-        .file(MockImage.getImageFile())
-        .file(new MockMultipartFile("request", "", "application/json",
-            valueAsString.getBytes(StandardCharsets.UTF_8)))
-        .contentType(MediaType.MULTIPART_FORM_DATA)
-        .accept(MediaType.APPLICATION_JSON)
-        .characterEncoding("UTF-8")
-        .with(csrf())
-        .header("X-AUTH-TOKEN", "testAccessToken"))
+            .file(MockImage.getImageFile())
+            .file(new MockMultipartFile("request", "", "application/json",
+                valueAsString.getBytes(StandardCharsets.UTF_8)))
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON)
+            .characterEncoding("UTF-8")
+            .with(csrf())
+            .header("X-AUTH-TOKEN", "testAccessToken"))
+
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithCustomMockUser
+  @DisplayName("[controller] 그림 하나 조회")
+  void success_search_painting() throws Exception {
+    //given=
+    given(paintingService.getPainting(anyString(), anyLong()))
+        .willReturn(ElasticSearchPainting.builder()
+            .id(1L)
+            .user(SimpleUserDto.builder()
+                .userId(1L)
+                .profileImgUrl("testProfileUrl")
+                .uid("testUid")
+                .name("testName")
+                .build())
+            .paintingImgUrl("testPaintingUrl")
+            .title("testTitle")
+            .description("testDescription")
+            .isSale(false)
+            .auctionPrice(0L)
+            .salePrice(0L)
+            .tags(Set.of("tag1", "tag2"))
+            .build());
+    //when
+    //then
+    mockMvc.perform(get("/api/v1/paintings/1")
+            .with(csrf()))
+
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.title").value("testTitle"))
+        .andDo(print());
+  }
+
+  @Test
+  @WithCustomMockUser
+  @DisplayName("[controller] 태그 변경")
+  void success_modify_painting_tags() throws Exception {
+    //given
+    Set<String> tagSet = new HashSet<>(List.of("tag1", "tag2", "tag3"));
+    given(paintingService.updatePaintingTags(anyString(), anyLong(), any()))
+        .willReturn(PaintingInputResponse.builder()
+            .paintingId(1L)
+            .title("testTitle")
+            .description("testDescription")
+            .tags(tagSet)
+            .build());
+
+    // request builder
+    PaintingModifyTagsRequest request =
+        PaintingModifyTagsRequest.builder()
+            .tags(tagSet)
+            .build();
+
+    String valueAsString = objectMapper.writeValueAsString(request);
+
+    //when
+    //then
+    mockMvc.perform(put("/api/v1/paintings/tags/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(valueAsString)
+            .with(csrf()))
+
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @WithCustomMockUser
+  @DisplayName("[controller] 가격 변경")
+  void success_modify_painting_price() throws Exception {
+    //given
+    given(paintingService.convertPaintingToSale(anyString(), anyLong(), any()))
+        .willReturn(PaintingInputResponse.builder()
+            .paintingId(1L)
+            .title("testTitle")
+            .description("testDescription")
+            .isSale(true)
+            .auctionPrice(10000L)
+            .salePrice(10000L)
+            .build());
+
+    // request builder
+    PaintingModifyPriceRequest request =
+        PaintingModifyPriceRequest.builder()
+            .auctionPrice(10000L)
+            .salePrice(10000L)
+            .build();
+
+    String valueAsString = objectMapper.writeValueAsString(request);
+
+    //when
+    //then
+    mockMvc.perform(put("/api/v1/paintings/1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(valueAsString)
+            .with(csrf()))
 
         .andExpect(status().isOk())
         .andDo(print());

--- a/src/test/java/org/jnjeaaaat/onbition/web/SignControllerTest.java
+++ b/src/test/java/org/jnjeaaaat/onbition/web/SignControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
+import org.jnjeaaaat.onbition.config.WithCustomMockUser;
 import org.jnjeaaaat.onbition.domain.dto.auth.ReissueResponse;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignInRequest;
 import org.jnjeaaaat.onbition.domain.dto.sign.SignInResponse;
@@ -47,6 +48,7 @@ class SignControllerTest {
 
 
   @Test
+  @WithCustomMockUser
   @DisplayName("[controller] 회원가입 성공")
   void success_register() throws Exception {
     //given
@@ -103,6 +105,7 @@ class SignControllerTest {
   }
 
   @Test
+  @WithCustomMockUser
   @DisplayName("[controller] 로그인 성공")
   void success_signIn() throws Exception {
     //given
@@ -121,7 +124,9 @@ class SignControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(
                 new SignInRequest("testUid", "password")
-            )))
+            ))
+            .characterEncoding("UTF-8")
+            .with(csrf()))
         .andExpect(jsonPath("$.result.uid").value("testUid"))
         .andExpect(jsonPath("$.result.roles[0]").value("ROLE_VIEWER"))
         .andExpect(jsonPath("$.result.accessToken").value("testAccessToken"))
@@ -131,6 +136,7 @@ class SignControllerTest {
   }
 
   @Test
+  @WithCustomMockUser
   @DisplayName("[controller] 토큰 재발급 성공")
   void reissue_token() throws Exception {
     //given
@@ -141,8 +147,9 @@ class SignControllerTest {
     //when
     //then
     mockMvc.perform(post("/api/v1/re-token")
-        .header("X-AUTH-TOKEN", "testAccessToken")
-        .header("refreshToken", "testRefreshToken"))
+            .header("X-AUTH-TOKEN", "testAccessToken")
+            .header("refreshToken", "testRefreshToken")
+            .with(csrf()))
         .andExpect(jsonPath("$.result.accessToken").value("testNewAccessToken"))
         .andExpect(status().isOk())
         .andDo(print());


### PR DESCRIPTION
Changes
---
- ElasticSearch 적용
   - docker-compose로 elasticsearch, kibana 실행
   - document class 작성
   - setting, mapping json 파일 작성
- Painting 저장할때 ES에도 저장
- Title, Tag로 검색
   - Page, Slice로 Slice 처리
   - 가격 범위 설정에 따른 검색 기능 구현
- Painting 정보 변경
   - 태그 목록 변경 
   - 판매여부, 가격 변경
   - ES도 set(), save()로 해결

Background
---
그림 조회에 대한 API를 구현하려고 하는데 ElasticSearch를 이용해 검색기능을 구현하고 싶었다.

Discuss
---
ElasticSearch로 query를 짜서 검색하고, 저장하고, 구현하는데에 깊게 고민하고 많은 시행착오가 있었는데
생각보다 간단하게 DB의 데이터를 다루는 것과 똑같이 Method naming 방식으로 많이 해결되었다.

Issues
---
#37 #38 #39