### PR TITLE
feat: [USER-BALANCE] 유저 잔액 관리

### DIFF
--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -39,6 +39,9 @@ public enum BaseStatus {
   // painting
   SUCCESS_CREATE_PAINTING(true, OK.value(), "그림을 등록하였습니다."),
 
+  // money
+  SUCCESS_CHANGE_MONEY(true, OK.value(), "잔액이 변경되었습니다."),
+
 
 
   //////////////////////////////// failed response ////////////////////////////////
@@ -65,6 +68,9 @@ public enum BaseStatus {
   // painting
   UNDER_MIN_PRICE(false, BAD_REQUEST.value(), "판매되는 그림의 가격은 1000원 이상이어야 합니다."),
   NOT_FOUND_PAINTING(false, BAD_REQUEST.value(), "해당 그림이 없습니다."),
+
+  // money
+  AMOUNT_LESS_THAN_CURRENT(false, BAD_REQUEST.value(), "잔액이 부족합니다."),
 
 
   // file

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/PaintingInputResponse.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
-import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.jnjeaaaat.onbition.domain.entity.Painting;
 
 /**

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/BalanceType.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/BalanceType.java
@@ -1,0 +1,9 @@
+package org.jnjeaaaat.onbition.domain.dto.pay;
+
+/**
+ * 입금, 출금 타입 enum
+ */
+public enum BalanceType {
+
+  DEPOSIT, WITHDRAW
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/ChangeMoneyRequest.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/ChangeMoneyRequest.java
@@ -1,0 +1,25 @@
+package org.jnjeaaaat.onbition.domain.dto.pay;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 잔액 입출금 Request class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChangeMoneyRequest {
+
+  private BalanceType balanceType;
+
+  @Min(1000)
+  private Long changeBalance;
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/ChangeMoneyResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/ChangeMoneyResponse.java
@@ -1,0 +1,36 @@
+package org.jnjeaaaat.onbition.domain.dto.pay;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
+import org.jnjeaaaat.onbition.domain.entity.pay.UserBalance;
+
+/**
+ * 입출금 Response class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChangeMoneyResponse {
+
+  private SimpleUserDto user;
+  private BalanceType balanceType;
+  private Long changeBalance;
+  private Long currentBalance;
+
+  public static ChangeMoneyResponse from(UserBalance userBalance) {
+    return ChangeMoneyResponse.builder()
+        .user(SimpleUserDto.from(userBalance.getUser()))
+        .balanceType(userBalance.getBalanceType())
+        .changeBalance(userBalance.getChangeBalance())
+        .currentBalance(userBalance.getCurrentBalance())
+        .build();
+
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/User.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/User.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import org.jnjeaaaat.onbition.domain.entity.pay.UserBalance;
 
 /**
  * SpringSecurity UserDetails 구현하는 User Entity
@@ -71,10 +72,21 @@ public class User extends BaseEntity {
   @Builder.Default
   private List<Painting> paintings = new ArrayList<>();
 
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<UserBalance> balances = new ArrayList<>();
+
   /*
   유저 새로운 권한 추가 method
    */
   public boolean addRoles(String newRole) {
     return this.roles.add(newRole);
+  }
+
+  /*
+  유저 권한 제거 method
+   */
+  public boolean removeRole(String role) {
+    return this.roles.remove(role);
   }
 }

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/OwnerHistory.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/OwnerHistory.java
@@ -1,0 +1,49 @@
+package org.jnjeaaaat.onbition.domain.entity.pay;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 그림 소유권 변경 history entity
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class OwnerHistory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;    // history pk
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private User user;  // 소유주
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "painting_id")
+  private Painting painting;  // 그림
+
+  @CreatedDate
+  private LocalDateTime ownedAt;  // 소유된 일자
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/Payment.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/Payment.java
@@ -1,0 +1,53 @@
+package org.jnjeaaaat.onbition.domain.entity.pay;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 결제 현황 entity
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Payment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;    // payment PK
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;    // 결제한 유저
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "painting_id")
+  private Painting painting;    // 결제된 그림
+
+  @Column(nullable = false)
+  private Long payAmount; // 결제 금액
+
+  @CreatedDate
+  private LocalDateTime createdAt;  // 결제 일자
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/UserBalance.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/UserBalance.java
@@ -1,0 +1,57 @@
+package org.jnjeaaaat.onbition.domain.entity.pay;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.dto.pay.BalanceType;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 유저 잔액 entity
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class UserBalance {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;    // user balance pk
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user; // 해당 유저
+
+  @Enumerated
+  @Column(nullable = false)
+  private BalanceType balanceType;  // 입출금 타입
+
+  @Column(nullable = false)
+  private Long changeBalance; // 변화된 잔액
+
+  @Column(nullable = false)
+  private Long currentBalance;  // 현재 잔액
+
+  @CreatedDate
+  private LocalDateTime createdAt;  // 입출금 일자
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/repository/pay/OwnerHistoryRepository.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/repository/pay/OwnerHistoryRepository.java
@@ -1,0 +1,13 @@
+package org.jnjeaaaat.onbition.domain.repository.pay;
+
+import org.jnjeaaaat.onbition.domain.entity.pay.OwnerHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 그림 소유 history Repository
+ */
+@Repository
+public interface OwnerHistoryRepository extends JpaRepository<OwnerHistory, Long> {
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/repository/pay/PaymentRepository.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/repository/pay/PaymentRepository.java
@@ -1,0 +1,13 @@
+package org.jnjeaaaat.onbition.domain.repository.pay;
+
+import org.jnjeaaaat.onbition.domain.entity.pay.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 결제 현황 repository
+ */
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/repository/pay/UserBalanceRepository.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/repository/pay/UserBalanceRepository.java
@@ -1,0 +1,18 @@
+package org.jnjeaaaat.onbition.domain.repository.pay;
+
+import java.util.List;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.entity.pay.UserBalance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 유저 잔액 repository
+ */
+@Repository
+public interface UserBalanceRepository extends JpaRepository<UserBalance, Long> {
+
+  // 해당 유저의 입출금 목록 Id값으로 내림차순
+  List<UserBalance> findAllByUserOrderByIdDesc(User user);
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/AccountService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/AccountService.java
@@ -1,0 +1,13 @@
+package org.jnjeaaaat.onbition.service;
+
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyRequest;
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyResponse;
+
+/**
+ * 입출금 service interface
+ */
+public interface AccountService {
+
+  // 입출금
+  ChangeMoneyResponse depositWithdraw(String uid, ChangeMoneyRequest request);
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
@@ -4,18 +4,13 @@ import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_USER;
 import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.UNDER_MIN_PRICE;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jnjeaaaat.onbition.domain.dto.file.FileFolder;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputRequest;
 import org.jnjeaaaat.onbition.domain.dto.paint.PaintingInputResponse;
-import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.jnjeaaaat.onbition.domain.entity.Painting;
 import org.jnjeaaaat.onbition.domain.entity.User;
-import org.jnjeaaaat.onbition.domain.repository.ElasticSearchPaintingRepository;
 import org.jnjeaaaat.onbition.domain.repository.PaintingRepository;
 import org.jnjeaaaat.onbition.domain.repository.UserRepository;
 import org.jnjeaaaat.onbition.exception.BaseException;
@@ -36,8 +31,6 @@ public class PaintingServiceImpl implements PaintingService {
 
   private final UserRepository userRepository;
   private final PaintingRepository paintingRepository;
-  private final PaintingSearchServiceImpl paintingSearchService;
-  private final ElasticSearchPaintingRepository elasticSearchPaintingRepository;
 
 
   private final String DREAMER = "ROLE_DREAMER";
@@ -81,19 +74,7 @@ public class PaintingServiceImpl implements PaintingService {
 
     Painting savedPainting = paintingRepository.save(painting);
 
-    // ES에 저장
-    log.info("[createPainting] ES 저장 시작");
-
-    elasticSearchPaintingRepository.save(ElasticSearchPainting.from(savedPainting));
-    log.info("[createPainting] ES 저장 끝");
-
     return PaintingInputResponse.from(savedPainting);
   }
 
-//  @Override
-//  public PaintingDetailResponse getPainting(String uid, Long paintingId) {
-//
-//    return PaintingDetailResponse.from(esPaintingRepository.findById(paintingId)
-//        .orElseThrow(() -> new BaseException(NOT_FOUND_PAINTING)));
-//  }
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/pay/AccountServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/pay/AccountServiceImpl.java
@@ -1,0 +1,104 @@
+package org.jnjeaaaat.onbition.service.impl.pay;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.AMOUNT_LESS_THAN_CURRENT;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_USER;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.domain.dto.pay.BalanceType;
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyRequest;
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyResponse;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.entity.pay.UserBalance;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.domain.repository.pay.UserBalanceRepository;
+import org.jnjeaaaat.onbition.exception.BaseException;
+import org.jnjeaaaat.onbition.service.AccountService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 입출금 service interface 구현체
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountServiceImpl implements AccountService {
+
+  private final UserBalanceRepository userBalanceRepository;
+  private final UserRepository userRepository;
+
+  private final String BUYER = "ROLE_BUYER";
+
+  /*
+  [입출금]
+  Request: user id, Change Money Type(deposit, withdraw), money amount
+  Response: User details, Change Money Type(deposit, withdraw), money amount, current money
+   */
+  @Override
+  @Transactional
+  public ChangeMoneyResponse depositWithdraw(String uid, ChangeMoneyRequest request) {
+    log.info("[depositWithdraw] 계좌 입금 & 출금 - 유저 id : {}", uid);
+
+    User user = userRepository.findByUidAndDeletedAtNull(uid)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+
+    Long currentBalance = userBalanceRepository.findAllByUserOrderByIdDesc(user)
+        .stream().findFirst()
+        .map(UserBalance::getCurrentBalance)
+        .orElse(0L);
+
+    UserBalance userBalance =
+        UserBalance.builder()
+            .user(user)
+            .balanceType(request.getBalanceType())
+            .changeBalance(request.getChangeBalance())
+            .currentBalance(currentBalance)
+            .build();
+
+    // 입금
+    if (request.getBalanceType().equals(BalanceType.DEPOSIT)) {
+      log.info("[depositWithdraw] 입금 요청");
+      depositMoney(user, userBalance, currentBalance, request.getChangeBalance());
+    }
+    // 출금
+    else if (request.getBalanceType().equals(BalanceType.WITHDRAW)) {
+      log.info("[depositWithdraw] 출금 요청");
+      withdrawMoney(user, userBalance, currentBalance, request.getChangeBalance());
+    }
+
+    return ChangeMoneyResponse.from(userBalance);
+  }
+
+  // 입금
+  private void depositMoney(User user, UserBalance userBalance, Long currentBalance,
+      Long changeBalance) {
+    userBalance.setCurrentBalance(currentBalance + changeBalance);
+
+    // 잔액이 1000원 이상이면 BUYER 권한
+    if (userBalance.getCurrentBalance() >= 1000) {
+      user.addRoles(BUYER);
+    }
+
+    userBalanceRepository.save(userBalance);
+  }
+
+  // 출금
+  private void withdrawMoney(User user, UserBalance userBalance, Long currentBalance,
+      Long changeBalance) {
+    // 잔액 부족
+    if (changeBalance > currentBalance) {
+      log.error("[withdrawMoney] 잔액 부족");
+      throw new BaseException(AMOUNT_LESS_THAN_CURRENT);
+    }
+    userBalance.setCurrentBalance(currentBalance - changeBalance);
+
+    // 잔액이 1000원 미만이 되면 BUYER 권한 없어짐
+    if (userBalance.getCurrentBalance() < 1000) {
+      user.removeRole(BUYER);
+    }
+
+    userBalanceRepository.save(userBalance);
+
+  }
+}

--- a/src/main/java/org/jnjeaaaat/onbition/web/BalanceController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/BalanceController.java
@@ -1,0 +1,49 @@
+package org.jnjeaaaat.onbition.web;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_CHANGE_MONEY;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.config.annotation.AuthUser;
+import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyRequest;
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyResponse;
+import org.jnjeaaaat.onbition.service.AccountService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/balances")
+public class BalanceController {
+
+  private final AccountService accountService;
+
+  /*
+  [입출금]
+  Request: user id, Change Money Type(deposit, withdraw), money amount
+  Response: User details, Change Money Type(deposit, withdraw), money amount, current money
+   */
+  @PostMapping
+  public BaseResponse<ChangeMoneyResponse> depositWithdraw(
+      @AuthUser UserDetails userDetails,
+      @RequestBody ChangeMoneyRequest request
+  ) {
+
+    log.info("[depositWithdraw] 계좌 입금 & 출금 요청");
+
+    return BaseResponse.success(
+        SUCCESS_CHANGE_MONEY,
+        accountService.depositWithdraw(userDetails.getUsername(), request)
+    );
+
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/PaintingController.java
@@ -51,18 +51,6 @@ public class PaintingController {
 
   }
 
-//  @GetMapping("/{paintingId}")
-//  public BaseResponse<PaintingDetailResponse> getPainting(
-//      @AuthUser UserDetails userDetails,
-//      @PathVariable Long paintingId) {
-//
-//    log.info("[getPainting] 그림 하나 조회 요청");
-//
-//    return BaseResponse.success(
-//        SUCCESS,
-//        paintingService.getPainting(userDetails.getUsername(), paintingId)
-//    );
-//  }
 
 
 }


### PR DESCRIPTION
Changes
---
- UserBalance history 엔티티 생성
   - 해당 유저, 입출금 타입, 금액, 현재잔액, 입출금한 날짜 저장
   - 입출금 타입은 enum으로 관리
- Controller
   - 입출금 타입, 금액 request
   - 해당 유저 simple detail, 입출금 타입, 금액, 현재잔액 response
- Service
   - 입출금 타입에 따라 현재잔액에서 해당 금액을 빼거나 더함
   - 현재잔액이 1000원이 넘으면 유저에 ROLE_BUYER 권한 추가
   - 다시 1000원 미만이 되면 ROLE_BUYER 권한 제거

Background
---
그림 결제를 위한 돈을 주고받아야 하기 위함으로
각 유저에 대한 돈 관리 기능을 만들어야함.

Issues
---
Resolve: #44