### PR TITLE
feat: [BUY-PAINTING] 그림 구매

### DIFF
--- a/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
+++ b/src/main/java/org/jnjeaaaat/onbition/config/security/SecurityConfig.java
@@ -46,6 +46,10 @@ public class SecurityConfig {
                 "/api/v1/sms/**"
             ).permitAll()
 
+            .requestMatchers(
+                "/api/v1/payments/{paintingId}"
+            ).hasAnyRole("BUYER")
+
             .anyRequest().authenticated()
         )
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/base/BaseStatus.java
@@ -42,6 +42,7 @@ public enum BaseStatus {
   SUCCESS_SEARCH_PAINTINGS_BY_TITLE(true, OK.value(), "제목으로 그림을 검색하였습니다."),
   SUCCESS_MODIFY_PAINTING_TAGS(true, OK.value(), "태그를 수정하였습니다."),
   SUCCESS_CONVERT_TO_SALE(true, OK.value(), "그림 판매를 시작합니다."),
+  SUCCESS_BUY_PAINTING(true, OK.value(), "그림을 구매하였습니다."),
 
   // money
   SUCCESS_CHANGE_MONEY(true, OK.value(), "잔액이 변경되었습니다."),
@@ -73,13 +74,14 @@ public enum BaseStatus {
   UNDER_MIN_PRICE(false, BAD_REQUEST.value(), "판매되는 그림의 가격은 1000원 이상이어야 합니다."),
   NOT_FOUND_PAINTING(false, BAD_REQUEST.value(), "해당 그림이 없습니다."),
   UN_MATCH_USER(false, BAD_REQUEST.value(), "그림의 소유자만 변경할 수 있습니다."),
+  ALREADY_OWNED_PAINTING(false, BAD_REQUEST.value(), "이미 그림의 소유주입니다."),
+  NOT_SALE_PAINTING(false, BAD_REQUEST.value(), "판매중인 그림이 아닙니다."),
 
   // painting elasticsearch
   WRONG_PRICE_RANGE(false, BAD_REQUEST.value(), "최소금액이 최대금액보다 클 수 없습니다."),
 
   // money
   AMOUNT_LESS_THAN_CURRENT(false, BAD_REQUEST.value(), "잔액이 부족합니다."),
-
 
   // file
   NOT_FOUND_FILE(false, INTERNAL_SERVER_ERROR.value(), "파일을 찾을 수 없습니다."),

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/SimplePaintingDto.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/paint/SimplePaintingDto.java
@@ -1,0 +1,34 @@
+package org.jnjeaaaat.onbition.domain.dto.paint;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+
+/**
+ * Painting 정보를 간단하게 나타낸 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SimplePaintingDto {
+
+  private Long id;
+  private String paintingImgUrl;  // 그림 url
+  private String title;  // 그림 제목
+  private String description;  // 그림 설명
+
+  public static SimplePaintingDto from(Painting painting) {
+    return SimplePaintingDto.builder()
+        .id(painting.getId())
+        .paintingImgUrl(painting.getPaintingImgUrl())
+        .title(painting.getTitle())
+        .description(painting.getDescription())
+        .build();
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/BuyPaintingResponse.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/dto/pay/BuyPaintingResponse.java
@@ -1,0 +1,23 @@
+package org.jnjeaaaat.onbition.domain.dto.pay;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jnjeaaaat.onbition.domain.dto.paint.SimplePaintingDto;
+
+/**
+ * 그림 구매 Response class
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BuyPaintingResponse {
+
+  private SimplePaintingDto painting;
+  private Long currentBalance;
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/UserBalance.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/entity/pay/UserBalance.java
@@ -3,6 +3,7 @@ package org.jnjeaaaat.onbition.domain.entity.pay;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -41,7 +42,7 @@ public class UserBalance {
   @JoinColumn(name = "user_id")
   private User user; // 해당 유저
 
-  @Enumerated
+  @Enumerated(EnumType.STRING)  // 0, 1, 2, ... 가 아닌 String 그대로 저장
   @Column(nullable = false)
   private BalanceType balanceType;  // 입출금 타입
 

--- a/src/main/java/org/jnjeaaaat/onbition/domain/repository/PaintingRepository.java
+++ b/src/main/java/org/jnjeaaaat/onbition/domain/repository/PaintingRepository.java
@@ -1,7 +1,11 @@
 package org.jnjeaaaat.onbition.domain.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
 import org.jnjeaaaat.onbition.domain.entity.Painting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,5 +13,9 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface PaintingRepository extends JpaRepository<Painting, Long> {
+
+  @NotNull
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  Optional<Painting> findById(@NotNull Long paintingId);
 
 }

--- a/src/main/java/org/jnjeaaaat/onbition/service/BalanceService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/BalanceService.java
@@ -6,7 +6,7 @@ import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyResponse;
 /**
  * 입출금 service interface
  */
-public interface AccountService {
+public interface BalanceService {
 
   // 입출금
   ChangeMoneyResponse depositWithdraw(String uid, ChangeMoneyRequest request);

--- a/src/main/java/org/jnjeaaaat/onbition/service/PaymentService.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/PaymentService.java
@@ -1,0 +1,12 @@
+package org.jnjeaaaat.onbition.service;
+
+import org.jnjeaaaat.onbition.domain.dto.pay.BuyPaintingResponse;
+
+/**
+ * 그림 구매, 결제 히스토리 service
+ */
+public interface PaymentService {
+
+  // 그림 구매
+  BuyPaintingResponse buyPainting(String uid, Long paintingId);
+}

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/paint/PaintingServiceImpl.java
@@ -20,9 +20,11 @@ import org.jnjeaaaat.onbition.domain.dto.paint.PaintingModifyTagsRequest;
 import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
 import org.jnjeaaaat.onbition.domain.entity.Painting;
 import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.entity.pay.OwnerHistory;
 import org.jnjeaaaat.onbition.domain.repository.ElasticSearchPaintingRepository;
 import org.jnjeaaaat.onbition.domain.repository.PaintingRepository;
 import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.domain.repository.pay.OwnerHistoryRepository;
 import org.jnjeaaaat.onbition.exception.BaseException;
 import org.jnjeaaaat.onbition.service.ImageService;
 import org.jnjeaaaat.onbition.service.PaintingService;
@@ -43,6 +45,7 @@ public class PaintingServiceImpl implements PaintingService {
   private final ImageService imageService;
 
   private final UserRepository userRepository;
+  private final OwnerHistoryRepository ownerHistoryRepository;
   private final PaintingRepository paintingRepository;
   private final ElasticSearchPaintingRepository elasticSearchPaintingRepository;
 
@@ -89,6 +92,14 @@ public class PaintingServiceImpl implements PaintingService {
     log.info("[createPainting] ES 저장 시작");
     elasticSearchPaintingRepository.save(ElasticSearchPainting.from(savedPainting));
     log.info("[createPainting] ES 저장 끝");
+
+    // owner history 추가
+    ownerHistoryRepository.save(
+        OwnerHistory.builder()
+            .user(user)
+            .painting(painting)
+            .build()
+    );
 
     return PaintingInputResponse.from(savedPainting);
   }

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/pay/BalanceServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/pay/BalanceServiceImpl.java
@@ -13,7 +13,7 @@ import org.jnjeaaaat.onbition.domain.entity.pay.UserBalance;
 import org.jnjeaaaat.onbition.domain.repository.UserRepository;
 import org.jnjeaaaat.onbition.domain.repository.pay.UserBalanceRepository;
 import org.jnjeaaaat.onbition.exception.BaseException;
-import org.jnjeaaaat.onbition.service.AccountService;
+import org.jnjeaaaat.onbition.service.BalanceService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AccountServiceImpl implements AccountService {
+public class BalanceServiceImpl implements BalanceService {
 
   private final UserBalanceRepository userBalanceRepository;
   private final UserRepository userRepository;

--- a/src/main/java/org/jnjeaaaat/onbition/service/impl/pay/PaymentServiceImpl.java
+++ b/src/main/java/org/jnjeaaaat/onbition/service/impl/pay/PaymentServiceImpl.java
@@ -1,0 +1,158 @@
+package org.jnjeaaaat.onbition.service.impl.pay;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.ALREADY_OWNED_PAINTING;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.AMOUNT_LESS_THAN_CURRENT;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_PAINTING;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_FOUND_USER;
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.NOT_SALE_PAINTING;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.domain.dto.paint.SimplePaintingDto;
+import org.jnjeaaaat.onbition.domain.dto.pay.BalanceType;
+import org.jnjeaaaat.onbition.domain.dto.pay.BuyPaintingResponse;
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyRequest;
+import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyResponse;
+import org.jnjeaaaat.onbition.domain.dto.user.SimpleUserDto;
+import org.jnjeaaaat.onbition.domain.entity.ElasticSearchPainting;
+import org.jnjeaaaat.onbition.domain.entity.Painting;
+import org.jnjeaaaat.onbition.domain.entity.User;
+import org.jnjeaaaat.onbition.domain.entity.pay.OwnerHistory;
+import org.jnjeaaaat.onbition.domain.entity.pay.Payment;
+import org.jnjeaaaat.onbition.domain.entity.pay.UserBalance;
+import org.jnjeaaaat.onbition.domain.repository.ElasticSearchPaintingRepository;
+import org.jnjeaaaat.onbition.domain.repository.PaintingRepository;
+import org.jnjeaaaat.onbition.domain.repository.UserRepository;
+import org.jnjeaaaat.onbition.domain.repository.pay.OwnerHistoryRepository;
+import org.jnjeaaaat.onbition.domain.repository.pay.PaymentRepository;
+import org.jnjeaaaat.onbition.domain.repository.pay.UserBalanceRepository;
+import org.jnjeaaaat.onbition.exception.BaseException;
+import org.jnjeaaaat.onbition.service.BalanceService;
+import org.jnjeaaaat.onbition.service.PaymentService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 그림 구매, 결제 히스토리 service 구현체
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService {
+
+  private final PaymentRepository paymentRepository;
+  private final OwnerHistoryRepository ownerHistoryRepository;
+  private final UserRepository userRepository;
+  private final UserBalanceRepository userBalanceRepository;
+  private final PaintingRepository paintingRepository;
+  private final ElasticSearchPaintingRepository elasticSearchPaintingRepository;
+
+  private final BalanceService balanceService;
+
+  private final String ARTIST = "ROLE_ARTIST";
+
+  /*
+  [그림 구매]
+  Request: user id, painting PK
+  Response: simple details of Painting, buyer's current balance
+   */
+  @Override
+  @Transactional
+  public BuyPaintingResponse buyPainting(String uid, Long paintingId) {
+
+    log.info("[buyPainting] 그림 구매 - 유저 id : {}, 그림 PK : {}", uid, paintingId);
+
+    // 구매를 하는 유저
+    User user = userRepository.findByUidAndDeletedAtNull(uid)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+
+    // 구매하려는 그림
+    Painting painting = paintingRepository.findById(paintingId)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_PAINTING));
+
+    // ES
+    ElasticSearchPainting esPainting = elasticSearchPaintingRepository.findById(paintingId)
+        .orElseThrow(() -> new BaseException(NOT_FOUND_PAINTING));
+
+    // 구매하려는 유저의 현재 잔액
+    Long currentBalance = userBalanceRepository.findAllByUserOrderByIdDesc(user)
+        .stream().findFirst()
+        .map(UserBalance::getCurrentBalance)
+        .orElse(0L);
+
+    // validation 확인
+    validateBuyPainting(painting, user, currentBalance);
+
+    /*
+     결제 진행
+     */
+    paymentRepository.save(
+        Payment.builder()
+            .user(user)
+            .painting(painting)
+            .payAmount(painting.getPrice())
+            .build()
+    );
+
+    // 결제하는 사람 잔액 출금
+    ChangeMoneyRequest withdrawRequest =
+        ChangeMoneyRequest.builder()
+            .balanceType(BalanceType.WITHDRAW)
+            .changeBalance(painting.getPrice())
+            .build();
+    // 현재 잔액을 포함한 response
+    ChangeMoneyResponse withdrawResponse = balanceService.depositWithdraw(user.getUid(), withdrawRequest);
+
+    // 그림 소유주한테 입금
+    ChangeMoneyRequest depositRequest =
+        ChangeMoneyRequest.builder()
+            .balanceType(BalanceType.DEPOSIT)
+            .changeBalance(painting.getPrice())
+            .build();
+    balanceService.depositWithdraw(painting.getUser().getUid(), depositRequest);
+
+    // ARTIST 권한 추가
+    if (painting.getUser().getRoles().contains("ROLE_DREAMER")) {  // 그림을 하나라도 등록한 유저일때
+      painting.getUser().addRoles(ARTIST);
+    }
+
+    // 소유권 변경 & isSale false & 가격변경
+    painting.setUser(user);
+    painting.setIsSale(false);
+    painting.setPrice(0L);
+
+    esPainting.setUser(SimpleUserDto.from(user));  // es user 변경
+    esPainting.setIsSale(false);
+    esPainting.setPrice(0L);
+    elasticSearchPaintingRepository.save(esPainting); // es 저장
+
+    ownerHistoryRepository.save(
+        OwnerHistory.builder()
+            .user(user)
+            .painting(painting)
+            .build()
+    );
+
+    return BuyPaintingResponse.builder()
+        .painting(SimplePaintingDto.from(painting))
+        .currentBalance(withdrawResponse.getCurrentBalance())  // 구매한 유저의 현재 잔액
+        .build();
+  }
+
+  // 그림 구매 validation
+  private void validateBuyPainting(Painting painting, User user, Long currentBalance) {
+    // 본인 그림일때
+    if (painting.getUser().equals(user)) {
+      throw new BaseException(ALREADY_OWNED_PAINTING);
+    }
+    // 그림이 판매중이 아닐때
+    if (painting.getIsSale().equals(false)) {
+      throw new BaseException(NOT_SALE_PAINTING);
+    }
+    // 그림의 가격보다 잔액이 적을때
+    if (painting.getPrice() > currentBalance) {
+      throw new BaseException(AMOUNT_LESS_THAN_CURRENT);
+    }
+  }
+
+}

--- a/src/main/java/org/jnjeaaaat/onbition/web/BalanceController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/BalanceController.java
@@ -9,7 +9,7 @@ import org.jnjeaaaat.onbition.config.annotation.AuthUser;
 import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
 import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyRequest;
 import org.jnjeaaaat.onbition.domain.dto.pay.ChangeMoneyResponse;
-import org.jnjeaaaat.onbition.service.AccountService;
+import org.jnjeaaaat.onbition.service.BalanceService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/balances")
 public class BalanceController {
 
-  private final AccountService accountService;
+  private final BalanceService balanceService;
 
   /*
   [입출금]
@@ -42,7 +42,7 @@ public class BalanceController {
 
     return BaseResponse.success(
         SUCCESS_CHANGE_MONEY,
-        accountService.depositWithdraw(userDetails.getUsername(), request)
+        balanceService.depositWithdraw(userDetails.getUsername(), request)
     );
 
   }

--- a/src/main/java/org/jnjeaaaat/onbition/web/PaymentController.java
+++ b/src/main/java/org/jnjeaaaat/onbition/web/PaymentController.java
@@ -1,0 +1,47 @@
+package org.jnjeaaaat.onbition.web;
+
+import static org.jnjeaaaat.onbition.domain.dto.base.BaseStatus.SUCCESS_BUY_PAINTING;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jnjeaaaat.onbition.config.annotation.AuthUser;
+import org.jnjeaaaat.onbition.domain.dto.base.BaseResponse;
+import org.jnjeaaaat.onbition.domain.dto.pay.BuyPaintingResponse;
+import org.jnjeaaaat.onbition.service.PaymentService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 그림 구매, 결제 히스토리 api
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/payments")
+public class PaymentController {
+
+  private final PaymentService paymentService;
+
+  /*
+  [그림 구매]
+  Request: user id, painting PK
+  Response: simple details of Painting, buyer's current balance
+   */
+  @PostMapping("/{paintingId}")
+  public BaseResponse<BuyPaintingResponse> buyPainting(
+      @AuthUser UserDetails userDetails,
+      @PathVariable Long paintingId) {
+
+    log.info("[buyPainting] 그림 구매 요청");
+
+    return BaseResponse.success(
+        SUCCESS_BUY_PAINTING,
+        paymentService.buyPainting(userDetails.getUsername(), paintingId)
+    );
+  }
+
+
+}


### PR DESCRIPTION
Changes
---
- PaymentController
   - 구매할 그림 PK, 구매하는 유저 id request
- PaymentService
   - 구매하려는 유저의 현재 잔액과 그림의 가격 비교
   - validation 처리 후 결제 진행
   - 어떤유저가 어떤그림을 얼마에 사는지 기록
   - 돈을 넘겨주는 행위는 구현해놓은 `입출금` method로 대체
   - 그림이 처음 판매되면 ARTIST 권한 추가
      - DREAMER 권한이 있어야 추가 가능
   - 해당 Painting 의 유저, 판매여부, 가격 변경
   - 해당 ElasticSearchPainting의 유저, 판매여부, 가격 변경
   - OwnerHistory(소유권 변경 히스토리)에 데이터 저장

Discuss
---
그림을 구매할때 많은 작업들을 해야하는데 (ex. 권한 추가, 소유권 변경, 그림 정보 수정, 입출금, validation)
모두다 따로 private 메소드로 구분하려면 똑같은 인자값을 계속 넘겨주고 처리해야하는데
메소드를 나누는게 무조건 맞는 방법인지 의아해하면서 로직을 구현했다.

Issues
---
Resolve: #46